### PR TITLE
Report error message correctly when request fails

### DIFF
--- a/promptlayer/utils.py
+++ b/promptlayer/utils.py
@@ -5,6 +5,7 @@ import os
 import sys
 import types
 from copy import deepcopy
+from json import JSONDecodeError
 
 import requests
 
@@ -131,16 +132,7 @@ def promptlayer_api_request(
             },
         )
         if request_response.status_code != 200:
-            if hasattr(request_response, "json"):
-                print(
-                    f"WARNING: While logging your request PromptLayer had the following error: {request_response.json().get('message')}",
-                    file=sys.stderr,
-                )
-            else:
-                print(
-                    f"WARNING: While logging your request PromptLayer had the following error: {request_response}",
-                    file=sys.stderr,
-                )
+            handle_bad_response(request_response, "WARNING: While logging your request PromptLayer had the following error")
     except Exception as e:
         print(
             f"WARNING: While logging your request PromptLayer had the following error: {e}",
@@ -190,19 +182,29 @@ def promptlayer_get_prompt(prompt_name, api_key, version=None):
             params={"prompt_name": prompt_name, "version": version},
         )
         if request_response.status_code != 200:
-            if hasattr(request_response, "json"):
-                raise Exception(
-                    f"PromptLayer had the following error while getting your prompt: {request_response.json().get('message')}"
-                )
-            else:
-                raise Exception(
-                    f"PromptLayer had the following error while getting your prompt: {request_response}"
-                )
+            handle_bad_response(request_response, "PromptLayer had the following error while getting your prompt")
     except Exception as e:
         raise Exception(
             f"PromptLayer had the following error while getting your prompt: {e}"
         )
     return request_response.json()
+
+
+def handle_bad_response(request_response, main_message):
+    if hasattr(request_response, "json"):
+        try:
+            raise Exception(
+                f"{main_message}: {request_response.json().get('message')}"
+            )
+        except JSONDecodeError:
+            print(
+                f"{main_message}: {request_response}",
+                file=sys.stderr,
+            )
+    else:
+        raise Exception(
+            f"{main_message}: {request_response}"
+        )
 
 
 def promptlayer_publish_prompt(prompt_name, prompt_template, tags, api_key):
@@ -217,14 +219,7 @@ def promptlayer_publish_prompt(prompt_name, prompt_template, tags, api_key):
             },
         )
         if request_response.status_code != 200:
-            if hasattr(request_response, "json"):
-                raise Exception(
-                    f"PromptLayer had the following error while publishing your prompt: {request_response.json().get('message')}"
-                )
-            else:
-                raise Exception(
-                    f"PromptLayer had the following error while publishing your prompt: {request_response}"
-                )
+            handle_bad_response(request_response, "PromptLayer had the following error while publishing your prompt")
     except Exception as e:
         raise Exception(
             f"PromptLayer had the following error while publishing your prompt: {e}"
@@ -247,18 +242,8 @@ def promptlayer_track_prompt(
             },
         )
         if request_response.status_code != 200:
-            if hasattr(request_response, "json"):
-                print(
-                    f"WARNING: While tracking your prompt PromptLayer had the following error: {request_response.json().get('message')}",
-                    file=sys.stderr,
-                )
-                return False
-            else:
-                print(
-                    f"WARNING: While tracking your prompt PromptLayer had the following error: {request_response}",
-                    file=sys.stderr,
-                )
-                return False
+            handle_bad_response(request_response, "WARNING: While tracking your prompt PromptLayer had the following error")
+            return False
     except Exception as e:
         print(
             f"WARNING: While tracking your prompt PromptLayer had the following error: {e}",
@@ -279,18 +264,8 @@ def promptlayer_track_metadata(request_id, metadata, api_key):
             },
         )
         if request_response.status_code != 200:
-            if hasattr(request_response, "json"):
-                print(
-                    f"WARNING: While tracking your metadata PromptLayer had the following error: {request_response.json().get('message')}",
-                    file=sys.stderr,
-                )
-                return False
-            else:
-                print(
-                    f"WARNING: While tracking your metadata PromptLayer had the following error: {request_response}",
-                    file=sys.stderr,
-                )
-                return False
+            handle_bad_response(request_response, "WARNING: While tracking your metadata PromptLayer had the following error")
+            return False
     except Exception as e:
         print(
             f"WARNING: While tracking your metadata PromptLayer had the following error: {e}",
@@ -311,18 +286,8 @@ def promptlayer_track_score(request_id, score, api_key):
             },
         )
         if request_response.status_code != 200:
-            if hasattr(request_response, "json"):
-                print(
-                    f"WARNING: While tracking your score PromptLayer had the following error: {request_response.json().get('message')}",
-                    file=sys.stderr,
-                )
-                return False
-            else:
-                print(
-                    f"WARNING: While tracking your score PromptLayer had the following error: {request_response}",
-                    file=sys.stderr,
-                )
-                return False
+            handle_bad_response(request_response, "WARNING: While tracking your score PromptLayer had the following error")
+            return False
     except Exception as e:
         print(
             f"WARNING: While tracking your score PromptLayer had the following error: {e}",

--- a/promptlayer/utils.py
+++ b/promptlayer/utils.py
@@ -115,6 +115,7 @@ def promptlayer_api_request(
 ):
     if type(response) != dict and hasattr(response, "to_dict_recursive"):
         response = response.to_dict_recursive()
+    request_response = None
     try:
         request_response = requests.post(
             f"{URL_API_PROMPTLAYER}/track-request",
@@ -133,13 +134,15 @@ def promptlayer_api_request(
         )
         if request_response.status_code != 200:
             handle_bad_response(request_response, "WARNING: While logging your request PromptLayer had the following error")
+        else:
+            if return_pl_id and request_response:
+                return request_response.json().get("request_id")
     except Exception as e:
         print(
             f"WARNING: While logging your request PromptLayer had the following error: {e}",
             file=sys.stderr,
         )
-    if return_pl_id:
-        return request_response.json().get("request_id")
+        raise e
 
 
 def promptlayer_api_request_async(

--- a/promptlayer/utils.py
+++ b/promptlayer/utils.py
@@ -192,41 +192,6 @@ def promptlayer_get_prompt(prompt_name, api_key, version=None):
     return request_response.json()
 
 
-def warn_on_bad_response(request_response, main_message):
-    if hasattr(request_response, "json"):
-        try:
-            print(
-                f"{main_message}: {request_response.json().get('message')}",
-                file=sys.stderr
-            )
-        except JSONDecodeError:
-            print(
-                f"{main_message}: {request_response}",
-                file=sys.stderr,
-            )
-    else:
-        print(
-            f"{main_message}: {request_response}",
-            file=sys.stderr
-        )
-
-
-def raise_on_bad_response(request_response, main_message):
-    if hasattr(request_response, "json"):
-        try:
-            raise Exception(
-                f"{main_message}: {request_response.json().get('message')}"
-            )
-        except JSONDecodeError:
-            raise Exception(
-                f"{main_message}: {request_response}"
-            )
-    else:
-        raise Exception(
-            f"{main_message}: {request_response}"
-        )
-
-
 def promptlayer_publish_prompt(prompt_name, prompt_template, tags, api_key):
     try:
         request_response = requests.post(
@@ -400,3 +365,39 @@ async def run_in_thread_async(executor, func, *args, **kwargs):
     func_call = functools.partial(ctx.run, func, *args, **kwargs)
     res = await loop.run_in_executor(executor, func_call)
     return res
+
+
+def warn_on_bad_response(request_response, main_message):
+    if hasattr(request_response, "json"):
+        try:
+            print(
+                f"{main_message}: {request_response.json().get('message')}",
+                file=sys.stderr
+            )
+        except JSONDecodeError:
+            print(
+                f"{main_message}: {request_response}",
+                file=sys.stderr,
+            )
+    else:
+        print(
+            f"{main_message}: {request_response}",
+            file=sys.stderr
+        )
+
+
+def raise_on_bad_response(request_response, main_message):
+    if hasattr(request_response, "json"):
+        try:
+            raise Exception(
+                f"{main_message}: {request_response.json().get('message')}"
+            )
+        except JSONDecodeError:
+            raise Exception(
+                f"{main_message}: {request_response}"
+            )
+    else:
+        raise Exception(
+            f"{main_message}: {request_response}"
+        )
+

--- a/promptlayer/utils.py
+++ b/promptlayer/utils.py
@@ -139,7 +139,7 @@ def promptlayer_api_request(
             f"WARNING: While logging your request PromptLayer had the following error: {e}",
             file=sys.stderr,
         )
-    if return_pl_id:
+    if request_response is not None and return_pl_id:
         return request_response.json().get("request_id")
 
 
@@ -182,12 +182,13 @@ def promptlayer_get_prompt(prompt_name, api_key, version=None):
             headers={"X-API-KEY": api_key},
             params={"prompt_name": prompt_name, "version": version},
         )
-        if request_response.status_code != 200:
-            raise_on_bad_response(request_response, "PromptLayer had the following error while getting your prompt")
     except Exception as e:
         raise Exception(
             f"PromptLayer had the following error while getting your prompt: {e}"
         )
+    if request_response.status_code != 200:
+        raise_on_bad_response(request_response, "PromptLayer had the following error while getting your prompt")
+
     return request_response.json()
 
 
@@ -237,12 +238,12 @@ def promptlayer_publish_prompt(prompt_name, prompt_template, tags, api_key):
                 "api_key": api_key,
             },
         )
-        if request_response.status_code != 200:
-            raise_on_bad_response(request_response, "PromptLayer had the following error while publishing your prompt")
     except Exception as e:
         raise Exception(
             f"PromptLayer had the following error while publishing your prompt: {e}"
         )
+    if request_response.status_code != 200:
+        raise_on_bad_response(request_response, "PromptLayer had the following error while publishing your prompt")
     return True
 
 


### PR DESCRIPTION
I've implemented a small fix to at least get the response status code, when a failure occurs. 

```
WARNING: While logging your request PromptLayer had the following error: <Response [403]>
Traceback (most recent call last):
  File "/Users/lfoppiano/anaconda3/envs/magneto/lib/python3.9/site-packages/requests/models.py", line 971, in json
    return complexjson.loads(self.text, **kwargs)
  File "/Users/lfoppiano/anaconda3/envs/magneto/lib/python3.9/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/Users/lfoppiano/anaconda3/envs/magneto/lib/python3.9/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/Users/lfoppiano/anaconda3/envs/magneto/lib/python3.9/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

I've also wrapped the code in the same method to reduce a bit the complexity. 

I think this could be improved: 
1. by printing directly the response body, but I leave this up to you. 
2. by avoiding throwing the error after, but the request has to fail at some point: 
      ```    
         if return_pl_id:
               return request_response.json().get("request_id")
      ```