### PR TITLE
Fixed `to_prompt` method in case output_parser unavailable

### DIFF
--- a/promptlayer/prompts/chat.py
+++ b/promptlayer/prompts/chat.py
@@ -42,11 +42,11 @@ def to_prompt(prompt_dict: dict):
             messages.append(message)
         prompt_template = prompts.ChatPromptTemplate(
             messages=messages,
-            input_variables=prompt_dict_copy.pop("input_variables"),
-            output_parser=prompt_dict_copy.pop("output_parser"),
-            partial_variables=prompt_dict_copy.pop("partial_variables"),
+            input_variables=prompt_dict_copy.get("input_variables", []),
+            output_parser=prompt_dict_copy.get("output_parser", None),
+            partial_variables=prompt_dict_copy.get("partial_variables", {}),
         )
         return prompt_template
     except Exception as e:
-        print(e)
+        print("Unknown error occurred. ", e)
         return None


### PR DESCRIPTION
Issue:

```python
prompt_template = promptlayer.prompts.get("test_template", langchain=True)
print(prompt_template)
``` 

The above prints the following output:
```text
'output_parser'
None
```

The expected output is of type `ChatPromptTemplate`. It prints above output because of a bug in the code of `to_prompt` method.
I've fixed the bug and submitting this PR to review and receive feedback.


<details><summary>System Details</summary>
<p>

Version: 0.1.93
Python: 3.10.12
Langchain: 0.0.247

</p>
</details> 