### PR TITLE
140 - Provider base URL library updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,9 @@ venv.bak/
 .dmypy.json
 dmypy.json
 
+# Pycharm
+.idea
+
 # Pyre type checker
 .pyre/
 

--- a/tests/test_get_prompt_template.py
+++ b/tests/test_get_prompt_template.py
@@ -8,7 +8,7 @@ def test_get_prompt_template_provider_base_url_name(capsys):
     promptlayer = PromptLayer(api_key=os.environ.get("PROMPTLAYER_API_KEY"))
 
     prompt_registry_name = f"test_template:{datetime.datetime.now()}"
-    provider_base_url_name = "test_provider_base_url_name"
+    provider_base_url_name = "does_not_exist"
 
     prompt_template = {
         "type": "chat",
@@ -43,4 +43,4 @@ def test_get_prompt_template_provider_base_url_name(capsys):
         prompt_registry_name, {"provider": "openai", "model": "gpt-3.5-turbo"}
     )
 
-    assert get_response['provider_base_url_name'] == provider_base_url_name
+    assert get_response['provider_base_url'] is None

--- a/tests/test_get_prompt_template.py
+++ b/tests/test_get_prompt_template.py
@@ -33,14 +33,16 @@ def test_get_prompt_template_provider_base_url_name(capsys):
         ],
     }
 
-    promptlayer.templates.publish({
-        "provider_base_url_name": provider_base_url_name,
-        "prompt_name": prompt_registry_name,
-        "prompt_template": prompt_template,
-    })
+    promptlayer.templates.publish(
+        {
+            "provider_base_url_name": provider_base_url_name,
+            "prompt_name": prompt_registry_name,
+            "prompt_template": prompt_template,
+        }
+    )
 
     get_response = promptlayer.templates.get(
         prompt_registry_name, {"provider": "openai", "model": "gpt-3.5-turbo"}
     )
 
-    assert get_response['provider_base_url'] is None
+    assert get_response["provider_base_url"] is None

--- a/tests/test_get_prompt_template.py
+++ b/tests/test_get_prompt_template.py
@@ -1,0 +1,46 @@
+import datetime
+import os
+
+from promptlayer import PromptLayer
+
+
+def test_get_prompt_template_provider_base_url_name(capsys):
+    promptlayer = PromptLayer(api_key=os.environ.get("PROMPTLAYER_API_KEY"))
+
+    prompt_registry_name = f"test_template:{datetime.datetime.now()}"
+    provider_base_url_name = "test_provider_base_url_name"
+
+    prompt_template = {
+        "type": "chat",
+        "provider_base_url_name": provider_base_url_name,
+        "messages": [
+            {
+                "content": [{"text": "You are an AI.", "type": "text"}],
+                "input_variables": [],
+                "name": None,
+                "raw_request_display_role": "",
+                "role": "system",
+                "template_format": "f-string",
+            },
+            {
+                "content": [{"text": "What is the capital of Japan?", "type": "text"}],
+                "input_variables": [],
+                "name": None,
+                "raw_request_display_role": "",
+                "role": "user",
+                "template_format": "f-string",
+            },
+        ],
+    }
+
+    promptlayer.templates.publish({
+        "provider_base_url_name": provider_base_url_name,
+        "prompt_name": prompt_registry_name,
+        "prompt_template": prompt_template,
+    })
+
+    get_response = promptlayer.templates.get(
+        prompt_registry_name, {"provider": "openai", "model": "gpt-3.5-turbo"}
+    )
+
+    assert get_response['provider_base_url_name'] == provider_base_url_name


### PR DESCRIPTION
Closes #140 

Depends on: https://github.com/MagnivOrg/prompt-layer-api/pull/1655

We do not allow users to create provider base URLs from the library yet. We only allow users to create new prompt templates/versions linked to existing provider base URLs. So I am unable to write a test for the rendering of a provider base URL exists, however in manual testing it is working fine.