### PR TITLE
148 - Add `run` method to PromptLayer class for executing prompts

### DIFF
--- a/promptlayer/__init__.py
+++ b/promptlayer/__init__.py
@@ -1,10 +1,30 @@
+import datetime
 import os
-from typing import Literal, Union
+from copy import deepcopy
+from typing import Dict, List, Literal, Union
 
 from promptlayer.groups import GroupManager
 from promptlayer.promptlayer import PromptLayerBase
 from promptlayer.templates import TemplateManager
 from promptlayer.track import TrackManager
+from promptlayer.types.prompt_template import GetPromptTemplate
+from promptlayer.utils import anthropic_request, openai_request, track_request
+
+MAP_PROVIDER_TO_FUNCTION_NAME = {
+    "openai": {
+        "chat": "openai.chat.completions.create",
+        "completion": "openai.completions.create",
+    },
+    "anthropic": {
+        "chat": "anthropic.messages.create",
+        "completion": "anthropic.completions.create",
+    },
+}
+
+MAP_PROVIDER_TO_FUNCTION = {
+    "openai": openai_request,
+    "anthropic": anthropic_request,
+}
 
 
 class PromptLayer:
@@ -43,6 +63,66 @@ class PromptLayer:
             return anthropic
         else:
             raise AttributeError(f"module {__name__} has no attribute {name}")
+
+    def run(
+        self,
+        prompt_name: str,
+        version: Union[int, None] = None,
+        label: Union[str, None] = None,
+        input_variables: Union[Dict[str, str], None] = None,
+        tags: Union[List[str], None] = None,
+        metadata: Union[Dict[str, str], None] = None,
+        group_id: Union[int, None] = None,
+    ):
+        template_get_params: GetPromptTemplate = {}
+        if version:
+            template_get_params["version"] = version
+        if label:
+            template_get_params["label"] = label
+        if input_variables:
+            template_get_params["input_variables"] = input_variables
+        prompt_blueprint = self.templates.get(prompt_name, template_get_params)
+        prompt_template = prompt_blueprint["prompt_template"]
+        if not prompt_blueprint["llm_kwargs"]:
+            raise Exception(
+                f"Prompt '{prompt_name}' does not have any LLM kwargs associated with it."
+            )
+        prompt_blueprint_metadata = prompt_blueprint.get("metadata", None)
+        if prompt_blueprint_metadata is None:
+            raise Exception(
+                f"Prompt '{prompt_name}' does not have any metadata associated with it."
+            )
+        prompt_blueprint_model = prompt_blueprint_metadata.get("model", None)
+        if prompt_blueprint_model is None:
+            raise Exception(
+                f"Prompt '{prompt_name}' does not have a model parameters associated with it."
+            )
+        provider = prompt_blueprint_model["provider"]
+        request_start_time = datetime.datetime.now(datetime.timezone.utc).timestamp()
+        kwargs = deepcopy(prompt_blueprint["llm_kwargs"])
+        function_name = MAP_PROVIDER_TO_FUNCTION_NAME[provider][prompt_template["type"]]
+        response = MAP_PROVIDER_TO_FUNCTION[provider](prompt_blueprint, **kwargs)
+        response = response.model_dump()
+
+        request_end_time = datetime.datetime.now(datetime.timezone.utc).timestamp()
+        request_log = track_request(
+            function_name=function_name,
+            provider=provider,
+            args=[],
+            kwargs=kwargs,
+            tags=tags,
+            request_response=response,
+            request_start_time=request_start_time,
+            request_end_time=request_end_time,
+            api_key=self.api_key,
+            metadata=metadata,
+            prompt_id=prompt_blueprint["id"],
+            prompt_version=prompt_blueprint["version"],
+            prompt_input_variables=input_variables,
+            group_id=group_id,
+            return_data=True,
+        )
+        return request_log
 
 
 __version__ = "1.0.2"

--- a/promptlayer/__init__.py
+++ b/promptlayer/__init__.py
@@ -120,6 +120,7 @@ class PromptLayer:
             group_id=group_id,
             return_data=True,
         )
+        request_log["raw_response"] = response
         return request_log
 
 

--- a/promptlayer/__init__.py
+++ b/promptlayer/__init__.py
@@ -88,8 +88,8 @@ class PromptLayer:
     def run(
         self,
         prompt_name: str,
-        version: Union[int, None] = None,
-        label: Union[str, None] = None,
+        prompt_version: Union[int, None] = None,
+        prompt_release_label: Union[str, None] = None,
         input_variables: Union[Dict[str, str], None] = None,
         tags: Union[List[str], None] = None,
         metadata: Union[Dict[str, str], None] = None,
@@ -97,10 +97,10 @@ class PromptLayer:
         stream=False,
     ):
         template_get_params: GetPromptTemplate = {}
-        if version:
-            template_get_params["version"] = version
-        if label:
-            template_get_params["label"] = label
+        if prompt_version:
+            template_get_params["version"] = prompt_version
+        if prompt_release_label:
+            template_get_params["label"] = prompt_release_label
         if input_variables:
             template_get_params["input_variables"] = input_variables
         prompt_blueprint = self.templates.get(prompt_name, template_get_params)

--- a/promptlayer/__init__.py
+++ b/promptlayer/__init__.py
@@ -88,15 +88,21 @@ class PromptLayer:
     def run(
         self,
         prompt_name: str,
-        template_get_params: Union[GetPromptTemplate, None] = None,
+        version: Union[int, None] = None,
+        label: Union[str, None] = None,
+        input_variables: Union[Dict[str, str], None] = None,
         tags: Union[List[str], None] = None,
         metadata: Union[Dict[str, str], None] = None,
         group_id: Union[int, None] = None,
         stream=False,
     ):
-        input_variables = {}
-        if template_get_params and "input_variables" in template_get_params:
-            input_variables = template_get_params["input_variables"]
+        template_get_params: GetPromptTemplate = {}
+        if version:
+            template_get_params["version"] = version
+        if label:
+            template_get_params["label"] = label
+        if input_variables:
+            template_get_params["input_variables"] = input_variables
         prompt_blueprint = self.templates.get(prompt_name, template_get_params)
         prompt_template = prompt_blueprint["prompt_template"]
         if not prompt_blueprint["llm_kwargs"]:

--- a/promptlayer/__init__.py
+++ b/promptlayer/__init__.py
@@ -123,5 +123,5 @@ class PromptLayer:
         return request_log
 
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 __all__ = ["PromptLayer", "__version__"]

--- a/promptlayer/__init__.py
+++ b/promptlayer/__init__.py
@@ -118,10 +118,14 @@ class PromptLayer:
             prompt_version=prompt_blueprint["version"],
             prompt_input_variables=input_variables,
             group_id=group_id,
-            return_data=True,
+            return_prompt_blueprint=True,
         )
-        request_log["raw_response"] = response
-        return request_log
+        data = {
+            "request_id": request_log["request_id"],
+            "raw_response": response,
+            "prompt_blueprint": request_log["prompt_blueprint"],
+        }
+        return data
 
 
 __version__ = "1.0.3"

--- a/promptlayer/types/prompt_template.py
+++ b/promptlayer/types/prompt_template.py
@@ -156,13 +156,27 @@ class PublishPromptTemplate(BasePromptTemplate, PromptVersion, total=False):
     release_labels: Optional[List[str]] = None
 
 
-class BasePromptTemplateResponse(TypedDict):
-    id: int
-    prompt_name: str
+class BaseProviderBaseURL(TypedDict):
+    name: Required[str]
+    provider: Required[str]
+    url: Required[str]
+
+
+class ProviderBaseURL(BaseProviderBaseURL):
+    id: Required[int]
+
+
+class BasePromptTemplateResponse(TypedDict, total=False):
+    id: Required[int]
+    prompt_name: Required[str]
     tags: List[str]
-    prompt_template: PromptTemplate
+    prompt_template: Required[PromptTemplate]
     commit_message: str
     metadata: Metadata
+    provider_base_url: ProviderBaseURL
+
+
+a: BasePromptTemplateResponse = {"provider_base_url": {"url": ""}}
 
 
 class PublishPromptTemplateResponse(BasePromptTemplateResponse):

--- a/promptlayer/types/prompt_template.py
+++ b/promptlayer/types/prompt_template.py
@@ -1,5 +1,7 @@
 from typing import Dict, List, Literal, Optional, Sequence, TypedDict, Union
 
+from typing_extensions import Required
+
 
 class GetPromptTemplate(TypedDict, total=False):
     version: int
@@ -110,15 +112,15 @@ Message = Union[
 
 
 class CompletionPromptTemplate(TypedDict, total=False):
-    type: Literal["completion"]
+    type: Required[Literal["completion"]]
     template_format: TemplateFormat
     content: Sequence[Content]
     input_variables: List[str]
 
 
 class ChatPromptTemplate(TypedDict, total=False):
-    type: Literal["chat"]
-    messages: Sequence[Message]
+    type: Required[Literal["chat"]]
+    messages: Required[Sequence[Message]]
     functions: Sequence[Function]
     function_call: Union[Literal["auto", "none"], ChatFunctionCall]
     input_variables: List[str]
@@ -130,9 +132,9 @@ PromptTemplate = Union[CompletionPromptTemplate, ChatPromptTemplate]
 
 
 class Model(TypedDict, total=False):
-    provider: str
-    name: str
-    parameters: Dict[str, object]
+    provider: Required[str]
+    name: Required[str]
+    parameters: Required[Dict[str, object]]
 
 
 class Metadata(TypedDict, total=False):

--- a/promptlayer/utils.py
+++ b/promptlayer/utils.py
@@ -458,9 +458,9 @@ class GeneratorProxy:
                     hasattr(result.choices[0].delta, "content")
                     and result.choices[0].delta.content is not None
                 ):
-                    response[
-                        "content"
-                    ] = f"{response['content']}{result.choices[0].delta.content}"
+                    response["content"] = (
+                        f"{response['content']}{result.choices[0].delta.content}"
+                    )
             final_result = deepcopy(self.results[-1])
             final_result.choices[0] = response
             return final_result
@@ -678,7 +678,7 @@ MAP_TYPE_TO_OPENAI_FUNCTION = {
 def openai_request(prompt_blueprint: GetPromptTemplateResponse, **kwargs):
     from openai import OpenAI
 
-    client = OpenAI()
+    client = OpenAI(base_url=kwargs.pop("base_url", None))
     request_to_make = MAP_TYPE_TO_OPENAI_FUNCTION[
         prompt_blueprint["prompt_template"]["type"]
     ]
@@ -702,7 +702,7 @@ MAP_TYPE_TO_ANTHROPIC_FUNCTION = {
 def anthropic_request(prompt_blueprint: GetPromptTemplateResponse, **kwargs):
     from anthropic import Anthropic
 
-    client = Anthropic()
+    client = Anthropic(base_url=kwargs.pop("base_url", None))
     request_to_make = MAP_TYPE_TO_ANTHROPIC_FUNCTION[
         prompt_blueprint["prompt_template"]["type"]
     ]

--- a/promptlayer/utils.py
+++ b/promptlayer/utils.py
@@ -458,9 +458,9 @@ class GeneratorProxy:
                     hasattr(result.choices[0].delta, "content")
                     and result.choices[0].delta.content is not None
                 ):
-                    response["content"] = (
-                        f"{response['content']}{result.choices[0].delta.content}"
-                    )
+                    response[
+                        "content"
+                    ] = f"{response['content']}{result.choices[0].delta.content}"
             final_result = deepcopy(self.results[-1])
             final_result.choices[0] = response
             return final_result

--- a/promptlayer/utils.py
+++ b/promptlayer/utils.py
@@ -8,7 +8,7 @@ import sys
 import types
 from copy import deepcopy
 from enum import Enum
-from typing import List, Union
+from typing import Callable, Generator, List, Union
 
 import requests
 
@@ -662,6 +662,142 @@ def track_request(**body):
             file=sys.stderr,
         )
         return {}
+
+
+def openai_stream_chat(results: list):
+    from openai.types.chat import (
+        ChatCompletion,
+        ChatCompletionChunk,
+        ChatCompletionMessage,
+    )
+    from openai.types.chat.chat_completion import ChatCompletion, Choice
+
+    chat_completion_chunks: List[ChatCompletionChunk] = results
+    response: ChatCompletion = ChatCompletion(
+        id="",
+        object="chat.completion",
+        choices=[
+            Choice(
+                finish_reason="stop",
+                index=0,
+                message=ChatCompletionMessage(role="assistant"),
+            )
+        ],
+        created=0,
+        model="",
+    )
+    last_result = chat_completion_chunks[-1]
+    response.id = last_result.id
+    response.created = last_result.created
+    response.model = last_result.model
+    content = ""
+    for result in chat_completion_chunks:
+        system_fingerprint = result.system_fingerprint
+        usage = result.usage
+        if len(result.choices) > 0 and result.choices[0].delta.content:
+            content = f"{content}{result.choices[0].delta.content}"
+        if usage:
+            response.usage = usage
+        if system_fingerprint:
+            response.system_fingerprint = system_fingerprint
+    response.choices[0].message.content = content
+    return response
+
+
+def openai_stream_completion(results: list):
+    from openai.types.completion import Completion, CompletionChoice
+
+    completions: List[Completion] = results
+    last_chunk = completions[-1]
+    response = Completion(
+        id=last_chunk.id,
+        created=last_chunk.created,
+        model=last_chunk.model,
+        object="text_completion",
+        choices=[CompletionChoice(finish_reason="stop", index=0, text="")],
+    )
+    text = ""
+    for completion in completions:
+        usage = completion.usage
+        system_fingerprint = completion.system_fingerprint
+        if len(completion.choices) > 0 and completion.choices[0].text:
+            text = f"{text}{completion.choices[0].text}"
+        if usage:
+            response.usage = usage
+        if system_fingerprint:
+            response.system_fingerprint = system_fingerprint
+    response.choices[0].text = text
+    return response
+
+
+def anthropic_stream_message(results: list):
+    from anthropic.types import Message, MessageStreamEvent, TextBlock, Usage
+
+    message_stream_events: List[MessageStreamEvent] = results
+    response: Message = Message(
+        id="",
+        model="",
+        content=[],
+        role="assistant",
+        type="message",
+        stop_reason="stop_sequence",
+        stop_sequence=None,
+        usage=Usage(input_tokens=0, output_tokens=0),
+    )
+    content = ""
+    for result in message_stream_events:
+        if result.type == "message_start":
+            response = result.message
+        elif result.type == "content_block_delta":
+            if result.delta.type == "text_delta":
+                content = f"{content}{result.delta.text}"
+        elif result.type == "message_delta":
+            if hasattr(result, "usage"):
+                response.usage.output_tokens = result.usage.output_tokens
+            if hasattr(result.delta, "stop_reason"):
+                response.stop_reason = result.delta.stop_reason
+    response.content.append(TextBlock(type="text", text=content))
+    return response
+
+
+def anthropic_stream_completion(results: list):
+    from anthropic.types import Completion
+
+    completions: List[Completion] = results
+    last_chunk = completions[-1]
+    response = Completion(
+        id=last_chunk.id,
+        completion="",
+        model=last_chunk.model,
+        stop_reason="stop",
+        type="completion",
+    )
+
+    text = ""
+    for completion in completions:
+        text = f"{text}{completion.completion}"
+    response.completion = text
+    return response
+
+
+def stream_response(
+    generator: Generator, after_stream: Callable, map_results: Callable
+):
+    data = {
+        "request_id": None,
+        "raw_response": None,
+        "prompt_blueprint": None,
+    }
+    results = []
+    for result in generator:
+        results.append(result)
+        data["raw_response"] = result
+        yield data
+    request_response = map_results(results)
+    response = after_stream(request_response=request_response.model_dump())
+    data["request_id"] = response.get("request_id")
+    data["prompt_blueprint"] = response.get("prompt_blueprint")
+    yield data
 
 
 def openai_chat_request(client, **kwargs):

--- a/promptlayer/utils.py
+++ b/promptlayer/utils.py
@@ -690,16 +690,12 @@ def openai_stream_chat(results: list):
     response.id = last_result.id
     response.created = last_result.created
     response.model = last_result.model
+    response.system_fingerprint = last_result.system_fingerprint
+    response.usage = last_result.usage
     content = ""
     for result in chat_completion_chunks:
-        system_fingerprint = result.system_fingerprint
-        usage = result.usage
         if len(result.choices) > 0 and result.choices[0].delta.content:
             content = f"{content}{result.choices[0].delta.content}"
-        if usage:
-            response.usage = usage
-        if system_fingerprint:
-            response.system_fingerprint = system_fingerprint
     response.choices[0].message.content = content
     return response
 

--- a/promptlayer/utils.py
+++ b/promptlayer/utils.py
@@ -670,7 +670,7 @@ def openai_stream_chat(results: list):
         ChatCompletionChunk,
         ChatCompletionMessage,
     )
-    from openai.types.chat.chat_completion import ChatCompletion, Choice
+    from openai.types.chat.chat_completion import Choice
 
     chat_completion_chunks: List[ChatCompletionChunk] = results
     response: ChatCompletion = ChatCompletion(

--- a/promptlayer/utils.py
+++ b/promptlayer/utils.py
@@ -458,9 +458,9 @@ class GeneratorProxy:
                     hasattr(result.choices[0].delta, "content")
                     and result.choices[0].delta.content is not None
                 ):
-                    response[
-                        "content"
-                    ] = f"{response['content']}{result.choices[0].delta.content}"
+                    response["content"] = (
+                        f"{response['content']}{result.choices[0].delta.content}"
+                    )
             final_result = deepcopy(self.results[-1])
             final_result.choices[0] = response
             return final_result
@@ -650,15 +650,18 @@ def track_request(**body):
             f"{URL_API_PROMPTLAYER}/track-request",
             json=body,
         )
-        if response.status_code == 200:
-            return response.json()
-        raise Exception(
-            f"PromptLayer had the following error while tracking your request: {response.text}"
-        )
+        if response.status_code != 200:
+            warn_on_bad_response(
+                response,
+                f"PromptLayer had the following error while tracking your request: {response.text}",
+            )
+        return response.json()
     except requests.exceptions.RequestException as e:
-        raise Exception(
-            f"PromptLayer had the following error while tracking your request: {e}"
+        print(
+            f"WARNING: While logging your request PromptLayer had the following error: {e}",
+            file=sys.stderr,
         )
+        return {}
 
 
 def openai_chat_request(client, **kwargs):

--- a/promptlayer/utils.py
+++ b/promptlayer/utils.py
@@ -642,3 +642,68 @@ def get_all_prompt_templates(
         raise Exception(
             f"PromptLayer had the following error while getting all your prompt templates: {e}"
         )
+
+
+def track_request(**body):
+    try:
+        response = requests.post(
+            f"{URL_API_PROMPTLAYER}/track-request",
+            json=body,
+        )
+        if response.status_code == 200:
+            return response.json()
+        raise Exception(
+            f"PromptLayer had the following error while tracking your request: {response.text}"
+        )
+    except requests.exceptions.RequestException as e:
+        raise Exception(
+            f"PromptLayer had the following error while tracking your request: {e}"
+        )
+
+
+def openai_chat_request(client, **kwargs):
+    return client.chat.completions.create(**kwargs)
+
+
+def openai_completions_request(client, **kwargs):
+    return client.completions.create(**kwargs)
+
+
+MAP_TYPE_TO_OPENAI_FUNCTION = {
+    "chat": openai_chat_request,
+    "completion": openai_completions_request,
+}
+
+
+def openai_request(prompt_blueprint: GetPromptTemplateResponse, **kwargs):
+    from openai import OpenAI
+
+    client = OpenAI()
+    request_to_make = MAP_TYPE_TO_OPENAI_FUNCTION[
+        prompt_blueprint["prompt_template"]["type"]
+    ]
+    return request_to_make(client, **kwargs)
+
+
+def anthropic_chat_request(client, **kwargs):
+    return client.messages.create(**kwargs)
+
+
+def anthropic_completions_request(client, **kwargs):
+    return client.completions.create(**kwargs)
+
+
+MAP_TYPE_TO_ANTHROPIC_FUNCTION = {
+    "chat": anthropic_chat_request,
+    "completion": anthropic_completions_request,
+}
+
+
+def anthropic_request(prompt_blueprint: GetPromptTemplateResponse, **kwargs):
+    from anthropic import Anthropic
+
+    client = Anthropic()
+    request_to_make = MAP_TYPE_TO_ANTHROPIC_FUNCTION[
+        prompt_blueprint["prompt_template"]["type"]
+    ]
+    return request_to_make(client, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "promptlayer"
-version = "1.0.2"
+version = "1.0.3"
 description = "PromptLayer is a platform for prompt engineering and tracks your LLM requests."
 authors = ["Magniv <hello@magniv.io>"]
 license = "Apache-2.0"


### PR DESCRIPTION
This pull request adds a new `run` method to the `PromptLayer` class. The `run` method allows for executing prompts with various parameters such as prompt name, version, label, input variables, tags, metadata, and group ID. It utilizes the existing `templates` and `track` modules to retrieve the prompt template and track the request. This new method enhances the functionality of the `PromptLayer` class and provides a convenient way to execute prompts.