### PR TITLE
152 - Remove direct dependency on LLM client SDKs

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1656,4 +1656,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "c0cc53131bf97de6a8288b036f3e0509ef7427f2998229d032a1be6ae187ec93"
+content-hash = "e886324bed1263b7740f6bc9d7e43a8e8e37bdbf677426996cc430bc437a5e96"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "promptlayer"
-version = "1.0.3"
+version = "1.0.4"
 description = "PromptLayer is a platform for prompt engineering and tracks your LLM requests."
 authors = ["Magniv <hello@magniv.io>"]
 license = "Apache-2.0"
@@ -9,15 +9,15 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
 requests = "^2.31.0"
-openai = "^1.26.0"
-anyio = "^4.3.0"
-anthropic = "^0.25.8"
 
 [tool.poetry.group.dev.dependencies]
 langchain = "^0.0.260"
 behave = "^1.2.6"
 pytest = "^8.2.0"
 pytest-asyncio = "^0.23.6"
+openai = "^1.26.0"
+anyio = "^4.3.0"
+anthropic = "^0.25.8"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
This pull request removes the direct dependency on LLM client SDKs. The changes include updating the version of the `promptlayer` package to `1.0.4` and updating the `tool.poetry.dependencies` section in the `pyproject.toml` file.