### PR TITLE
164 - Update typing annotations for input variables in PromptLayer and prompt template files

### DIFF
--- a/promptlayer/__init__.py
+++ b/promptlayer/__init__.py
@@ -1,7 +1,7 @@
 import datetime
 import os
 from copy import deepcopy
-from typing import Dict, List, Literal, Union
+from typing import Any, Dict, List, Literal, Union
 
 from promptlayer.groups import GroupManager
 from promptlayer.promptlayer import PromptLayerBase
@@ -90,7 +90,7 @@ class PromptLayer:
         prompt_name: str,
         prompt_version: Union[int, None] = None,
         prompt_release_label: Union[str, None] = None,
-        input_variables: Union[Dict[str, str], None] = None,
+        input_variables: Union[Dict[str, Any], None] = None,
         tags: Union[List[str], None] = None,
         metadata: Union[Dict[str, str], None] = None,
         group_id: Union[int, None] = None,

--- a/promptlayer/types/prompt_template.py
+++ b/promptlayer/types/prompt_template.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Literal, Optional, Sequence, TypedDict, Union
+from typing import Any, Dict, List, Literal, Optional, Sequence, TypedDict, Union
 
 from typing_extensions import Required
 
@@ -7,7 +7,7 @@ class GetPromptTemplate(TypedDict, total=False):
     version: int
     label: str
     provider: str
-    input_variables: Dict[str, str]
+    input_variables: Dict[str, Any]
     metadata_filters: Dict[str, str]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "promptlayer"
-version = "1.0.7"
+version = "1.0.8"
 description = "PromptLayer is a platform for prompt engineering and tracks your LLM requests."
 authors = ["Magniv <hello@magniv.io>"]
 license = "Apache-2.0"


### PR DESCRIPTION
This pull request updates the typing annotations for the `input_variables` parameter in the `run` function of the `PromptLayerBase` class and the `input_variables` field in the `GetPromptTemplate` TypedDict. The `input_variables` parameter and field are now annotated as `Dict[str, Any]` instead of `Dict[str, str]`. This change allows for more flexibility in the types of values that can be passed as input variables.