### PR TITLE
186 - Allow initializing multiple clients with tracing

### DIFF
--- a/promptlayer/__init__.py
+++ b/promptlayer/__init__.py
@@ -1,4 +1,4 @@
 from .promptlayer import PromptLayer
 
-__version__ = "1.0.17"
+__version__ = "1.0.18"
 __all__ = ["PromptLayer", "__version__"]

--- a/promptlayer/promptlayer.py
+++ b/promptlayer/promptlayer.py
@@ -321,15 +321,15 @@ class PromptLayer:
         return prompt_blueprint_model
 
     def run(
-            self,
-            prompt_name: str,
-            prompt_version: Union[int, None] = None,
-            prompt_release_label: Union[str, None] = None,
-            input_variables: Union[Dict[str, Any], None] = None,
-            tags: Union[List[str], None] = None,
-            metadata: Union[Dict[str, str], None] = None,
-            group_id: Union[int, None] = None,
-            stream: bool = False,
+        self,
+        prompt_name: str,
+        prompt_version: Union[int, None] = None,
+        prompt_release_label: Union[str, None] = None,
+        input_variables: Union[Dict[str, Any], None] = None,
+        tags: Union[List[str], None] = None,
+        metadata: Union[Dict[str, str], None] = None,
+        group_id: Union[int, None] = None,
+        stream: bool = False,
     ) -> Dict[str, Any]:
         _run_internal_kwargs = {
             "prompt_name": prompt_name,

--- a/promptlayer/promptlayer.py
+++ b/promptlayer/promptlayer.py
@@ -5,7 +5,6 @@ from copy import deepcopy
 from functools import wraps
 from typing import Any, Dict, List, Literal, Union
 
-from opentelemetry import trace
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
@@ -74,7 +73,9 @@ class PromptLayer:
         self.api_key = api_key
         self.templates = TemplateManager(api_key)
         self.group = GroupManager(api_key)
-        self.tracer_provider, self.tracer = self._initialize_tracer(api_key, enable_tracing)
+        self.tracer_provider, self.tracer = self._initialize_tracer(
+            api_key, enable_tracing
+        )
         self.track = TrackManager(api_key)
 
     def __getattr__(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "promptlayer"
-version = "1.0.17"
+version = "1.0.18"
 description = "PromptLayer is a platform for prompt engineering and tracks your LLM requests."
 authors = ["Magniv <hello@magniv.io>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Closes #186 

By default, OpenTelemetry doesn't allow multiple TracerProviders to be set globally. These changes modify the PromptLayer class to use a per-instance TracerProvider instead of relying on the global one. It does this by:
1. Creating a new TracerProvider for each PromptLayer instance.
2. Storing this TracerProvider as an instance variable instead of setting it globally.
3. Using the instance's TracerProvider to create a Tracer, also stored as an instance variable.
4. Using these instance-specific TracerProvider and Tracer for all tracing operations within that PromptLayer instance.