### PR TITLE
consolidate lints, add py.typed

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,8 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.290
+    rev: v0.9.0
     hooks:
       - id: ruff
         args:
-          [--exclude, features, --ignore, "E501", --fix, --exit-non-zero-on-fix]
-
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.9.1
-    hooks:
-      - id: black
-        args: [--force-exclude, features]
-
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        name: isort (python)
-        args: [--profile, black, --skip, features, --filter-files]
+          [--exclude, features, --ignore, "E501", --fix, --exit-non-zero-on-fix, --select, "E,F,I"]
+      - id: ruff-format

--- a/promptlayer/promptlayer_base.py
+++ b/promptlayer/promptlayer_base.py
@@ -51,7 +51,7 @@ class PromptLayerBase(object):
         ):
             return PromptLayerBase(
                 attr,
-                function_name=f'{object.__getattribute__(self, "_function_name")}.{name}',
+                function_name=f"{object.__getattribute__(self, '_function_name')}.{name}",
                 provider_type=object.__getattribute__(self, "_provider_type"),
                 api_key=object.__getattribute__(self, "_api_key"),
                 tracer=object.__getattribute__(self, "_tracer"),

--- a/promptlayer/track/__init__.py
+++ b/promptlayer/track/__init__.py
@@ -1,6 +1,5 @@
-from promptlayer.track.track import agroup, ametadata, aprompt, ascore, group
+from promptlayer.track.track import agroup, ametadata, aprompt, ascore, group, prompt
 from promptlayer.track.track import metadata as metadata_
-from promptlayer.track.track import prompt
 from promptlayer.track.track import score as score_
 
 

--- a/promptlayer/utils.py
+++ b/promptlayer/utils.py
@@ -748,9 +748,9 @@ class GeneratorProxy:
                     hasattr(result.choices[0].delta, "content")
                     and result.choices[0].delta.content is not None
                 ):
-                    response["content"] = response[
-                        "content"
-                    ] = f"{response['content']}{result.choices[0].delta.content}"
+                    response["content"] = response["content"] = (
+                        f"{response['content']}{result.choices[0].delta.content}"
+                    )
             final_result = deepcopy(self.results[-1])
             final_result.choices[0] = response
             return final_result


### PR DESCRIPTION
Ruff serves as a drop-in replacement for both [isort](https://docs.astral.sh/ruff/rules/#isort-i) and [Black](https://docs.astral.sh/ruff/formatter/), streamlining code formatting and import sorting within a single tool.

Additionally, the inclusion of py.typed ensures compatibility with type-checking tools, as outlined in [PEP 561](https://peps.python.org/pep-0561/#packaging-type-information).