### PR TITLE
Support using the environment variable `GEMINI_API_KEY` in addition to `GOOGLE_API_KEY`

### DIFF
--- a/promptlayer/__init__.py
+++ b/promptlayer/__init__.py
@@ -1,4 +1,4 @@
 from .promptlayer import AsyncPromptLayer, PromptLayer
 
-__version__ = "1.0.46"
+__version__ = "1.0.47"
 __all__ = ["PromptLayer", "AsyncPromptLayer", "__version__"]

--- a/promptlayer/utils.py
+++ b/promptlayer/utils.py
@@ -1767,7 +1767,9 @@ MAP_TYPE_TO_GOOGLE_FUNCTION = {
 def google_request(request: GetPromptTemplateResponse, **kwargs):
     from google import genai
 
-    client = genai.Client()
+    # First look for env variable "GOOGLE_API_KEY". Default to "GEMINI_API_KEY" if that doesn't exist
+    api_key = os.environ.get("GOOGLE_API_KEY") or os.environ.get("GEMINI_API_KEY")
+    client = genai.Client(api_key=api_key)
     request_to_make = MAP_TYPE_TO_GOOGLE_FUNCTION[request["prompt_template"]["type"]]
     return request_to_make(client, **kwargs)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "promptlayer"
-version = "1.0.46"
+version = "1.0.47"
 description = "PromptLayer is a platform for prompt engineering and tracks your LLM requests."
 authors = ["Magniv <hello@magniv.io>"]
 license = "Apache-2.0"


### PR DESCRIPTION
`promptlayer.run` requires `GOOGLE_API_KEY` to be set when using a Google model.

Add in support to also allow users to alternatively use `GEMINI_API_KEY` (official google docs [here](https://ai.google.dev/gemini-api/docs/api-key#macos---zsh) use `GEMINI_API_KEY` as the environment variable).

We already use `GOOGLE_API_KEY` elsewhere in our code base so we cannot set this environment variable.