### PR TITLE
Fix bad return type for async `run_workflow`

### DIFF
--- a/promptlayer/promptlayer.py
+++ b/promptlayer/promptlayer.py
@@ -387,7 +387,7 @@ class AsyncPromptLayer(PromptLayerMixin):
         # Allows `workflow_name` to be passed both as keyword and positional argument
         # (virtually identical to `workflow_id_or_name`)
         workflow_name: Optional[str] = None,
-    ) -> Dict[str, Any]:
+    ) -> Union[Dict[str, Any], Any]:
         try:
             return await arun_workflow_request(
                 workflow_id_or_name=_get_workflow_workflow_id_or_name(workflow_id_or_name, workflow_name),


### PR DESCRIPTION
Return type of this function is wrong. The sync version of this function has the appropriate return type but not the async one