### PR TITLE
fix: URL-encode workflow names with special characters in _resolve_workflow_id

### DIFF
--- a/promptlayer/utils.py
+++ b/promptlayer/utils.py
@@ -242,7 +242,7 @@ async def _resolve_workflow_id(base_url: str, workflow_id_or_name: Union[int, st
     # TODO(dmu) LOW: Should we warn user here to avoid using workflow names in favor of workflow id?
     async with _make_httpx_client() as client:
         # TODO(dmu) MEDIUM: Generalize the way we make async calls to PromptLayer API and reuse it everywhere
-        response = await client.get(f"{base_url}/workflows/{workflow_id_or_name}", headers=headers)
+        response = await client.get(f"{base_url}/workflows/{quote(str(workflow_id_or_name), safe='')}", headers=headers)
         if response.status_code != 200:
             raise_on_bad_response(response, "PromptLayer had the following error while resolving workflow")
 


### PR DESCRIPTION
## Problem

Fixes #254

When a workflow is created with a name containing special characters like slashes (e.g. `team/my-workflow`), calling it via the Python client fails because `_resolve_workflow_id` builds the lookup URL as:

```
{base_url}/workflows/{workflow_id_or_name}
```

The unencoded slash is interpreted by the server as a path separator, causing a 404 or wrong-resource lookup.

## Root Cause

`_resolve_workflow_id` in `promptlayer/utils.py` interpolates `workflow_id_or_name` directly into the URL path without encoding:

```python
# Before (line 245)
response = await client.get(f"{base_url}/workflows/{workflow_id_or_name}", headers=headers)
```

The `prompt-templates` endpoint already received this same fix (merged in PR #291). This PR closes the remaining gap for workflow name lookup.

## Fix

```python
# After
response = await client.get(f"{base_url}/workflows/{quote(str(workflow_id_or_name), safe=)}", headers=headers)
```

`urllib.parse.quote(..., safe=)` — already imported in `utils.py` — encodes ALL special characters so the workflow name is always transmitted as a single opaque path segment.

## Tests

Added `TestUrlEncodingInResolveWorkflowId` to `tests/test_get_prompt_template.py`:

| Test | Description |
|------|-------------|
| `test_resolve_workflow_id_encodes_slashes` | `team/my-workflow` → `team%2Fmy-workflow` in URL |
| `test_resolve_workflow_id_encodes_special_chars` | `org/project:v2@prod` → all chars encoded |
| `test_resolve_workflow_id_integer_unchanged` | Integer IDs bypass the HTTP call entirely |

All 11 tests in `test_get_prompt_template.py` pass (`pytest tests/test_get_prompt_template.py`).