### PR TITLE
Add RegistryTool type to prompt template types

### DIFF
--- a/promptlayer/__init__.py
+++ b/promptlayer/__init__.py
@@ -16,7 +16,7 @@ from .exceptions import (
 )
 from .promptlayer import AsyncPromptLayer, PromptLayer
 
-__version__ = "1.4.2"
+__version__ = "1.4.3"
 __all__ = [
     "PromptLayer",
     "AsyncPromptLayer",

--- a/promptlayer/types/prompt_template.py
+++ b/promptlayer/types/prompt_template.py
@@ -254,6 +254,13 @@ class BuiltInTool(TypedDict, total=False):
     name: str
 
 
+class RegistryTool(TypedDict, total=False):
+    type: Literal["registry"]
+    tool_registry_id: int
+    label: Optional[str]
+    version_number: Optional[int]
+
+
 class FunctionCall(TypedDict, total=False):
     name: str
     arguments: str
@@ -356,7 +363,7 @@ class ChatPromptTemplate(TypedDict, total=False):
     functions: Sequence[Function]
     function_call: Union[Literal["auto", "none"], ChatFunctionCall]
     input_variables: List[str]
-    tools: Sequence[Union[Tool, BuiltInTool]]
+    tools: Sequence[Union[Tool, BuiltInTool, RegistryTool]]
     tool_choice: ToolChoice
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "promptlayer"
-version = "1.4.2"
+version = "1.4.3"
 description = "PromptLayer is a platform for prompt engineering and tracks your LLM requests."
 authors = ["Magniv <hello@magniv.io>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Add `RegistryTool` TypedDict for the new Tool Registry feature. Prompts can now reference tools from the registry via `{type: "registry", tool_registry_id, label, version_number}`. These references are resolved to function definitions at      
  render time by the backend.