### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a Python SDK library (`promptlayer`). There are no servers or databases to run.
+
+### Quick reference
+
+| Task | Command |
+|------|---------|
+| Install deps | `poetry install` |
+| Lint | `make lint` |
+| Tests | `poetry run pytest` |
+| Tests (with `.env`) | `make test` |
+
+### Gotchas
+
+- **`make test` requires a `.env` file** — the Makefile's `test` target unconditionally sources `.env`. If the file doesn't exist the shell errors out. Use `poetry run pytest` directly instead, or create an empty `.env` file first.
+- **`pre-commit` is not a Poetry dependency** — it must be installed separately inside the Poetry virtualenv: `poetry run pip install pre-commit`. This is needed before `make lint` will work.
+- **Tests run fully offline** — VCR cassettes replay all HTTP calls. No API keys or network access are needed. The `pytest-network` plugin disables network by default.
+- **Re-recording cassettes** requires `PROMPTLAYER_API_KEY`, `OPENAI_API_KEY`, and `ANTHROPIC_API_KEY` env vars, plus setting `PROMPTLAYER_IS_CASSETTE_RECORDING=true`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents.

### What's included

- Quick reference table for common commands (`poetry install`, `make lint`, `poetry run pytest`)
- Documented gotchas:
  - `make test` requires a `.env` file (use `poetry run pytest` directly instead)
  - `pre-commit` must be installed separately in the Poetry venv for `make lint`
  - Tests run fully offline via VCR cassettes
  - Re-recording cassettes requires API keys

### Verification

All checks pass:

- **Lint**: `make lint` — all 5 pre-commit hooks pass
- **Tests**: `poetry run pytest` — 214/214 tests pass
- **SDK demo**: Client initialization, Jinja2 template rendering, error handling, proxy wrappers all working

[test_output.log](https://cursor.com/agents/bc-95239d31-a84a-4bf1-98a5-cf6b3a5b9217/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftest_output.log)
[lint_output.log](https://cursor.com/agents/bc-95239d31-a84a-4bf1-98a5-cf6b3a5b9217/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flint_output.log)
[hello_world_demo.log](https://cursor.com/agents/bc-95239d31-a84a-4bf1-98a5-cf6b3a5b9217/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_demo.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95239d31-a84a-4bf1-98a5-cf6b3a5b9217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95239d31-a84a-4bf1-98a5-cf6b3a5b9217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

