### PR TITLE
fix: URL-encode workflow names

### DIFF
--- a/promptlayer/utils.py
+++ b/promptlayer/utils.py
@@ -250,7 +250,7 @@ async def _resolve_workflow_id(base_url: str, workflow_id_or_name: Union[int, st
     # TODO(dmu) LOW: Should we warn user here to avoid using workflow names in favor of workflow id?
     async with _make_httpx_client() as client:
         # TODO(dmu) MEDIUM: Generalize the way we make async calls to PromptLayer API and reuse it everywhere
-        response = await client.get(f"{base_url}/workflows/{workflow_id_or_name}", headers=headers)
+        response = await client.get(f"{base_url}/workflows/{quote(str(workflow_id_or_name), safe='')}", headers=headers)
         if response.status_code != 200:
             raise_on_bad_response(response, "PromptLayer had the following error while resolving workflow")
 

--- a/tests/test_agents/test_arun_workflow_request.py
+++ b/tests/test_agents/test_arun_workflow_request.py
@@ -6,9 +6,30 @@ import pytest
 from ably.realtime.realtime_channel import RealtimeChannel
 from pytest_parametrize_cases import Case, parametrize_cases
 
-from promptlayer.utils import arun_workflow_request
+from promptlayer.utils import _resolve_workflow_id, arun_workflow_request
 from tests.utils.mocks import Any
 from tests.utils.vcr import assert_played, is_cassette_recording
+
+
+@pytest.mark.asyncio
+async def test_resolve_workflow_id_encodes_workflow_name(base_url: str, headers):
+    workflow_name = "feature1/resolve_problem_2:v1#draft"
+    expected_url = f"{base_url}/workflows/feature1%2Fresolve_problem_2%3Av1%23draft"
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"workflow": {"id": 3}}
+
+    with patch("promptlayer.utils._make_httpx_client") as mock_client_factory:
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mock_client_factory.return_value = mock_client
+
+        assert await _resolve_workflow_id(base_url, workflow_name, headers) == 3
+
+        mock_client.get.assert_awaited_once_with(expected_url, headers=headers)
 
 
 @patch("promptlayer.utils.WS_TOKEN_REQUEST_LIBRARY_URL", "http://localhost:8000/ws-token-request-library")


### PR DESCRIPTION
Closes #254

## Summary
- URL-encode workflow names before interpolating them into the `/workflows/{name}` path segment.
- Add a regression test covering slash and special-character workflow names.

## Tests
- `/tmp/promptlayer-venv/bin/python -m pytest tests/test_agents/test_arun_workflow_request.py -q`
- `/tmp/promptlayer-venv/bin/python -m pytest tests/test_get_prompt_template.py -q`