### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/promptlayer/promptlayer.py
+++ b/promptlayer/promptlayer.py
@@ -91,7 +91,7 @@ class PromptLayer(PromptLayerMixin):
 
     def __getattr__(
         self,
-        name: Union[Literal["openai"], Literal["anthropic"], Literal["prompts"]],
+        name: Union[Literal["openai"], Literal["anthropic"], Literal["litellm"], Literal["prompts"]],
     ):
         if name == "openai":
             import openai as openai_module
@@ -108,6 +108,16 @@ class PromptLayer(PromptLayerMixin):
                 anthropic_module,
                 function_name="anthropic",
                 provider_type="anthropic",
+                tracer=self.tracer,
+            )
+        elif name == "litellm":
+            import litellm as litellm_module
+
+            return PromptLayerBase(
+                self.api_key,
+                self.base_url,
+                litellm_module,
+                function_name="litellm",
                 tracer=self.tracer,
             )
         else:
@@ -477,7 +487,7 @@ class AsyncPromptLayer(PromptLayerMixin):
         """Invalidate SDK template cache for a prompt or entirely."""
         self.templates.invalidate(prompt_name)
 
-    def __getattr__(self, name: Union[Literal["openai"], Literal["anthropic"], Literal["prompts"]]):
+    def __getattr__(self, name: Union[Literal["openai"], Literal["anthropic"], Literal["litellm"], Literal["prompts"]]):
         if name == "openai":
             import openai as openai_module
 
@@ -497,6 +507,16 @@ class AsyncPromptLayer(PromptLayerMixin):
                 tracer=self.tracer,
             )
             return anthropic
+        elif name == "litellm":
+            import litellm as litellm_module
+
+            return PromptLayerBase(
+                self.api_key,
+                self.base_url,
+                litellm_module,
+                function_name="litellm",
+                tracer=self.tracer,
+            )
         else:
             raise AttributeError(f"module {__name__} has no attribute {name}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ tenacity = "^9.1.2"
 cachetools = "^5.0.0"
 openai-agents = {version = "^0.3.3", optional = true}
 claude-agent-sdk = {version = ">=0.1.45,<1.0.0", optional = true, python = ">=3.10,<4.0"}
+litellm = {version = ">=1.80.0,<1.87.0", optional = true}
 opentelemetry-exporter-otlp-proto-http = {version = "^1.26.0", optional = true}
 eval-type-backport = {version = "^0.3.1", optional = true}
 jinja2 = "^3.1.6"
@@ -51,6 +52,7 @@ aioboto3 = "^13.0.0"
 [tool.poetry.extras]
 openai-agents = ["openai-agents", "opentelemetry-exporter-otlp-proto-http", "eval-type-backport"]
 claude-agents = ["claude-agent-sdk"]
+litellm = ["litellm"]
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION


## Summary
- Adds [LiteLLM](https://github.com/BerriAI/litellm) as a tracked provider alongside OpenAI and Anthropic
- Users can access 100+ LLM providers through PromptLayer's observability layer via `pl.litellm`

## Motivation
PromptLayer currently wraps OpenAI and Anthropic modules for prompt tracking. Users wanting to track calls to other providers (Google Gemini, AWS Bedrock, Cohere, Mistral, etc.) have no path through PromptLayer's tracking layer. LiteLLM provides a unified interface that follows the OpenAI response format, making it a natural fit for the existing `PromptLayerBase` wrapper pattern.


## Changes
- `promptlayer/promptlayer.py` - Added `litellm` case to `__getattr__` in both `PromptLayer` (sync) and `AsyncPromptLayer` (async) classes, wrapping the litellm module via `PromptLayerBase` with `function_name="litellm"`.
- `pyproject.toml` - Added `litellm` as optional dependency (`>=1.80.0,<1.87.0`) and `litellm` extra (`pip install promptlayer[litellm]`).

## Tests

**Live E2E against Anthropic Claude Sonnet 4.6 (via Azure AI Foundry):**
```
>>> import litellm
>>> resp = litellm.completion(model='anthropic/claude-sonnet-4-6', messages=[...], drop_params=True)
Response: 4
Model: claude-sonnet-4-6
```

## Risk / Compatibility
- Additive only. Existing `openai` and `anthropic` providers untouched.
- `litellm` is an optional extra - base install unaffected (`pip install promptlayer[litellm]` to enable).
- LiteLLM returns OpenAI-compatible response objects, so `PromptLayerBase` tracking works without modification.

## Example usage

**Install:**
```bash
pip install promptlayer[litellm]
```

**Python usage:**
```python
from promptlayer import PromptLayer

pl = PromptLayer(api_key="pl_...")

# Use LiteLLM through PromptLayer's tracking layer
# All calls are logged to PromptLayer dashboard
response = pl.litellm.completion(
    model="anthropic/claude-sonnet-4-6",
    messages=[{"role": "user", "content": "What is 2+2?"}],
    drop_params=True,
)
print(response.choices[0].message.content)

# Works with any of 100+ providers:
#   'anthropic/claude-sonnet-4-6'  -> Anthropic API
#   'gemini/gemini-2.0-flash'     -> Google Gemini API
#   'openai/gpt-4o'               -> OpenAI API
#   'bedrock/anthropic.claude-v2' -> AWS Bedrock
```
