### PR TITLE
Fix prompt template names with slashes

### DIFF
--- a/promptlayer/utils.py
+++ b/promptlayer/utils.py
@@ -81,9 +81,9 @@ _requests_session: Optional[requests.Session] = None
 _requests_session_lock = threading.Lock()
 
 
-def _quote_prompt_template_path_segment(prompt_name: str) -> str:
-    # Some API edge layers decode the path once before routing; keep slashes encoded after that pass.
-    return quote(prompt_name, safe="").replace("%2F", "%252F")
+def _quote_api_path_segment(value: Union[int, str]) -> str:
+    # Some API edge layers decode path parameters once before routing.
+    return quote(str(value), safe="").replace("%2F", "%252F")
 
 
 def _get_requests_session() -> requests.Session:
@@ -255,7 +255,9 @@ async def _resolve_workflow_id(base_url: str, workflow_id_or_name: Union[int, st
     # TODO(dmu) LOW: Should we warn user here to avoid using workflow names in favor of workflow id?
     async with _make_httpx_client() as client:
         # TODO(dmu) MEDIUM: Generalize the way we make async calls to PromptLayer API and reuse it everywhere
-        response = await client.get(f"{base_url}/workflows/{workflow_id_or_name}", headers=headers)
+        response = await client.get(
+            f"{base_url}/workflows/{_quote_api_path_segment(workflow_id_or_name)}", headers=headers
+        )
         if response.status_code != 200:
             raise_on_bad_response(response, "PromptLayer had the following error while resolving workflow")
 
@@ -1593,7 +1595,7 @@ def get_prompt_template(
         if params:
             json_body = {**json_body, **params}
         response = _get_requests_session().post(
-            f"{base_url}/prompt-templates/{_quote_prompt_template_path_segment(prompt_name)}",
+            f"{base_url}/prompt-templates/{_quote_api_path_segment(prompt_name)}",
             headers={"X-API-KEY": api_key},
             json=json_body,
         )
@@ -1645,7 +1647,7 @@ async def aget_prompt_template(
             json_body.update(params)
         async with _make_httpx_client() as client:
             response = await client.post(
-                f"{base_url}/prompt-templates/{_quote_prompt_template_path_segment(prompt_name)}",
+                f"{base_url}/prompt-templates/{_quote_api_path_segment(prompt_name)}",
                 headers={"X-API-KEY": api_key},
                 json=json_body,
             )

--- a/promptlayer/utils.py
+++ b/promptlayer/utils.py
@@ -81,6 +81,11 @@ _requests_session: Optional[requests.Session] = None
 _requests_session_lock = threading.Lock()
 
 
+def _quote_prompt_template_path_segment(prompt_name: str) -> str:
+    # Some API edge layers decode the path once before routing; keep slashes encoded after that pass.
+    return quote(prompt_name, safe="").replace("%2F", "%252F")
+
+
 def _get_requests_session() -> requests.Session:
     """Get or create a module-level requests.Session for connection pooling.
 
@@ -1588,7 +1593,7 @@ def get_prompt_template(
         if params:
             json_body = {**json_body, **params}
         response = _get_requests_session().post(
-            f"{base_url}/prompt-templates/{quote(prompt_name, safe='')}",
+            f"{base_url}/prompt-templates/{_quote_prompt_template_path_segment(prompt_name)}",
             headers={"X-API-KEY": api_key},
             json=json_body,
         )
@@ -1640,7 +1645,7 @@ async def aget_prompt_template(
             json_body.update(params)
         async with _make_httpx_client() as client:
             response = await client.post(
-                f"{base_url}/prompt-templates/{quote(prompt_name, safe='')}",
+                f"{base_url}/prompt-templates/{_quote_prompt_template_path_segment(prompt_name)}",
                 headers={"X-API-KEY": api_key},
                 json=json_body,
             )

--- a/tests/test_agents/test_arun_workflow_request.py
+++ b/tests/test_agents/test_arun_workflow_request.py
@@ -6,9 +6,30 @@ import pytest
 from ably.realtime.realtime_channel import RealtimeChannel
 from pytest_parametrize_cases import Case, parametrize_cases
 
-from promptlayer.utils import arun_workflow_request
+from promptlayer.utils import _resolve_workflow_id, arun_workflow_request
 from tests.utils.mocks import Any
 from tests.utils.vcr import assert_played, is_cassette_recording
+
+
+@pytest.mark.asyncio
+async def test_resolve_workflow_id_encodes_slashes_for_path_routing(base_url: str, headers):
+    workflow_name = "feature1/resolve_problem_2:v1#draft"
+    expected_url = f"{base_url}/workflows/feature1%252Fresolve_problem_2%3Av1%23draft"
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"workflow": {"id": 3}}
+
+    with patch("promptlayer.utils._make_httpx_client") as mock_client_factory:
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mock_client_factory.return_value = mock_client
+
+        assert await _resolve_workflow_id(base_url, workflow_name, headers) == 3
+
+        mock_client.get.assert_awaited_once_with(expected_url, headers=headers)
 
 
 @patch("promptlayer.utils.WS_TOKEN_REQUEST_LIBRARY_URL", "http://localhost:8000/ws-token-request-library")

--- a/tests/test_get_prompt_template.py
+++ b/tests/test_get_prompt_template.py
@@ -10,9 +10,9 @@ class TestUrlEncodingInGetPromptTemplate:
     """Tests for URL encoding of prompt names in get_prompt_template and aget_prompt_template."""
 
     def test_sync_get_prompt_template_encodes_slashes(self, promptlayer_api_key, base_url):
-        """Prompt names with slashes should be URL-encoded."""
+        """Prompt names with slashes should stay encoded after one edge decode."""
         prompt_name = "feature1/resolve_problem_2"
-        expected_encoded = "feature1%2Fresolve_problem_2"
+        expected_encoded = "feature1%252Fresolve_problem_2"
 
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -32,7 +32,7 @@ class TestUrlEncodingInGetPromptTemplate:
             call_args = mock_session.return_value.post.call_args
             actual_url = call_args[0][0]
             assert expected_encoded in actual_url, f"Expected {expected_encoded} in URL, got {actual_url}"
-            assert "/" + prompt_name not in actual_url, "Unencoded slash found in URL"
+            assert actual_url == f"{base_url}/prompt-templates/{expected_encoded}"
 
     def test_sync_get_prompt_template_encodes_colons(self, promptlayer_api_key, base_url):
         """Prompt names with colons should be URL-encoded."""
@@ -83,7 +83,7 @@ class TestUrlEncodingInGetPromptTemplate:
     def test_sync_get_prompt_template_encodes_special_chars(self, promptlayer_api_key, base_url):
         """Prompt names with various special characters should be URL-encoded."""
         prompt_name = "test/prompt:name@v1#latest"
-        # URL encoding: / -> %2F, : -> %3A, @ -> %40, # -> %23
+        expected_encoded = "test%252Fprompt%3Aname%40v1%23latest"
 
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -101,17 +101,13 @@ class TestUrlEncodingInGetPromptTemplate:
 
             call_args = mock_session.return_value.post.call_args
             actual_url = call_args[0][0]
-            # Verify special characters are encoded
-            assert "%2F" in actual_url, "Slash not encoded"
-            assert "%3A" in actual_url, "Colon not encoded"
-            assert "%40" in actual_url, "At sign not encoded"
-            assert "%23" in actual_url, "Hash not encoded"
+            assert actual_url == f"{base_url}/prompt-templates/{expected_encoded}"
 
     @pytest.mark.asyncio
     async def test_async_get_prompt_template_encodes_slashes(self, promptlayer_api_key, base_url):
-        """Async: Prompt names with slashes should be URL-encoded."""
+        """Async: Prompt names with slashes should stay encoded after one edge decode."""
         prompt_name = "feature1/resolve_problem_2"
-        expected_encoded = "feature1%2Fresolve_problem_2"
+        expected_encoded = "feature1%252Fresolve_problem_2"
 
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -134,7 +130,7 @@ class TestUrlEncodingInGetPromptTemplate:
             call_args = mock_client.post.call_args
             actual_url = call_args[0][0]
             assert expected_encoded in actual_url, f"Expected {expected_encoded} in URL, got {actual_url}"
-            assert "/" + prompt_name not in actual_url, "Unencoded slash found in URL"
+            assert actual_url == f"{base_url}/prompt-templates/{expected_encoded}"
 
     @pytest.mark.asyncio
     async def test_async_get_prompt_template_encodes_colons(self, promptlayer_api_key, base_url):
@@ -168,6 +164,7 @@ class TestUrlEncodingInGetPromptTemplate:
     async def test_async_get_prompt_template_encodes_special_chars(self, promptlayer_api_key, base_url):
         """Async: Prompt names with various special characters should be URL-encoded."""
         prompt_name = "test/prompt:name@v1#latest"
+        expected_encoded = "test%252Fprompt%3Aname%40v1%23latest"
 
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -189,11 +186,7 @@ class TestUrlEncodingInGetPromptTemplate:
 
             call_args = mock_client.post.call_args
             actual_url = call_args[0][0]
-            # Verify special characters are encoded
-            assert "%2F" in actual_url, "Slash not encoded"
-            assert "%3A" in actual_url, "Colon not encoded"
-            assert "%40" in actual_url, "At sign not encoded"
-            assert "%23" in actual_url, "Hash not encoded"
+            assert actual_url == f"{base_url}/prompt-templates/{expected_encoded}"
 
 
 def test_get_prompt_template_provider_base_url_name(capsys, promptlayer_client):


### PR DESCRIPTION
Closes #254.

## Summary
- double-encode slashes in prompt template path segments so they survive an edge/router decode
- keep other special characters encoded once
- cover sync and async template fetches

## Tests
```powershell
$env:PYTHONPATH=(Get-Location).Path
& '..\prompt-layer-library-master\.venv\Scripts\python.exe' -m pytest tests\test_get_prompt_template.py -q
& '..\prompt-layer-library-master\.venv\Scripts\python.exe' -m pytest tests\test_get_prompt_template.py tests\test_agents\test_arun_workflow_request.py -q
```