### PR TITLE
Fix slash handling in PromptLayer API path segments

### DIFF
--- a/promptlayer/utils.py
+++ b/promptlayer/utils.py
@@ -76,6 +76,12 @@ WS_TOKEN_REQUEST_LIBRARY_URL = (
 
 logger = logging.getLogger(__name__)
 
+
+def _quote_api_path_segment(value: str) -> str:
+    """Quote one API path segment, preserving encoded slashes through one router decode."""
+    return quote(value, safe="").replace("%2F", "%252F")
+
+
 # Module-level session for connection pooling (thread-safe initialization)
 _requests_session: Optional[requests.Session] = None
 _requests_session_lock = threading.Lock()
@@ -250,7 +256,10 @@ async def _resolve_workflow_id(base_url: str, workflow_id_or_name: Union[int, st
     # TODO(dmu) LOW: Should we warn user here to avoid using workflow names in favor of workflow id?
     async with _make_httpx_client() as client:
         # TODO(dmu) MEDIUM: Generalize the way we make async calls to PromptLayer API and reuse it everywhere
-        response = await client.get(f"{base_url}/workflows/{workflow_id_or_name}", headers=headers)
+        response = await client.get(
+            f"{base_url}/workflows/{_quote_api_path_segment(workflow_id_or_name)}",
+            headers=headers,
+        )
         if response.status_code != 200:
             raise_on_bad_response(response, "PromptLayer had the following error while resolving workflow")
 
@@ -1588,7 +1597,7 @@ def get_prompt_template(
         if params:
             json_body = {**json_body, **params}
         response = _get_requests_session().post(
-            f"{base_url}/prompt-templates/{quote(prompt_name, safe='')}",
+            f"{base_url}/prompt-templates/{_quote_api_path_segment(prompt_name)}",
             headers={"X-API-KEY": api_key},
             json=json_body,
         )
@@ -1640,7 +1649,7 @@ async def aget_prompt_template(
             json_body.update(params)
         async with _make_httpx_client() as client:
             response = await client.post(
-                f"{base_url}/prompt-templates/{quote(prompt_name, safe='')}",
+                f"{base_url}/prompt-templates/{_quote_api_path_segment(prompt_name)}",
                 headers={"X-API-KEY": api_key},
                 json=json_body,
             )

--- a/tests/test_agents/test_arun_workflow_request.py
+++ b/tests/test_agents/test_arun_workflow_request.py
@@ -6,9 +6,35 @@ import pytest
 from ably.realtime.realtime_channel import RealtimeChannel
 from pytest_parametrize_cases import Case, parametrize_cases
 
-from promptlayer.utils import arun_workflow_request
+from promptlayer.utils import _resolve_workflow_id, arun_workflow_request
 from tests.utils.mocks import Any
 from tests.utils.vcr import assert_played, is_cassette_recording
+
+
+@pytest.mark.asyncio
+async def test_resolve_workflow_id_double_encodes_slashes(base_url: str, promptlayer_api_key):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"workflow": {"id": 123}}
+
+    with patch("promptlayer.utils._make_httpx_client") as mock_client_factory:
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mock_client_factory.return_value = mock_client
+
+        assert (
+            await _resolve_workflow_id(
+                base_url,
+                "feature1/resolve_problem_2",
+                {"X-API-KEY": promptlayer_api_key},
+            )
+            == 123
+        )
+
+        actual_url = mock_client.get.call_args[0][0]
+        assert actual_url.endswith("/workflows/feature1%252Fresolve_problem_2")
 
 
 @patch("promptlayer.utils.WS_TOKEN_REQUEST_LIBRARY_URL", "http://localhost:8000/ws-token-request-library")

--- a/tests/test_get_prompt_template.py
+++ b/tests/test_get_prompt_template.py
@@ -10,9 +10,9 @@ class TestUrlEncodingInGetPromptTemplate:
     """Tests for URL encoding of prompt names in get_prompt_template and aget_prompt_template."""
 
     def test_sync_get_prompt_template_encodes_slashes(self, promptlayer_api_key, base_url):
-        """Prompt names with slashes should be URL-encoded."""
+        """Prompt names with slashes should survive one router decode pass."""
         prompt_name = "feature1/resolve_problem_2"
-        expected_encoded = "feature1%2Fresolve_problem_2"
+        expected_encoded = "feature1%252Fresolve_problem_2"
 
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -83,7 +83,7 @@ class TestUrlEncodingInGetPromptTemplate:
     def test_sync_get_prompt_template_encodes_special_chars(self, promptlayer_api_key, base_url):
         """Prompt names with various special characters should be URL-encoded."""
         prompt_name = "test/prompt:name@v1#latest"
-        # URL encoding: / -> %2F, : -> %3A, @ -> %40, # -> %23
+        # URL encoding: / -> %252F to survive one router decode, : -> %3A, @ -> %40, # -> %23
 
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -102,16 +102,16 @@ class TestUrlEncodingInGetPromptTemplate:
             call_args = mock_session.return_value.post.call_args
             actual_url = call_args[0][0]
             # Verify special characters are encoded
-            assert "%2F" in actual_url, "Slash not encoded"
+            assert "%252F" in actual_url, "Slash not double-encoded"
             assert "%3A" in actual_url, "Colon not encoded"
             assert "%40" in actual_url, "At sign not encoded"
             assert "%23" in actual_url, "Hash not encoded"
 
     @pytest.mark.asyncio
     async def test_async_get_prompt_template_encodes_slashes(self, promptlayer_api_key, base_url):
-        """Async: Prompt names with slashes should be URL-encoded."""
+        """Async: Prompt names with slashes should survive one router decode pass."""
         prompt_name = "feature1/resolve_problem_2"
-        expected_encoded = "feature1%2Fresolve_problem_2"
+        expected_encoded = "feature1%252Fresolve_problem_2"
 
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -190,7 +190,7 @@ class TestUrlEncodingInGetPromptTemplate:
             call_args = mock_client.post.call_args
             actual_url = call_args[0][0]
             # Verify special characters are encoded
-            assert "%2F" in actual_url, "Slash not encoded"
+            assert "%252F" in actual_url, "Slash not double-encoded"
             assert "%3A" in actual_url, "Colon not encoded"
             assert "%40" in actual_url, "At sign not encoded"
             assert "%23" in actual_url, "Hash not encoded"


### PR DESCRIPTION
Closes #254

## Summary
- add a shared path-segment encoder that double-encodes `/` so prompt and workflow names survive one edge/router decode pass
- use it for sync and async prompt template fetches
- use it when resolving workflow names
- add regression coverage for slash-containing prompt and workflow names

## Verification
- `python -m pytest tests\test_get_prompt_template.py tests\test_agents\test_arun_workflow_request.py -q`
- `python -m ruff check promptlayer\utils.py tests\test_get_prompt_template.py tests\test_agents\test_arun_workflow_request.py`
- `python -m ruff format --check promptlayer\utils.py tests\test_get_prompt_template.py tests\test_agents\test_arun_workflow_request.py`
