### PR TITLE
fix: double-encode slashes in API path segments (#254)

### DIFF
--- a/promptlayer/utils.py
+++ b/promptlayer/utils.py
@@ -14,6 +14,14 @@ from enum import Enum
 from importlib.metadata import PackageNotFoundError, version as get_package_version
 from typing import Any, Callable, Coroutine, Dict, List, Optional, Union
 from urllib.parse import quote
+
+
+def _quote_api_path_segment(value: Union[int, str]) -> str:
+    """Quote one API path segment, preserving encoded slashes through one router decode."""
+    encoded = quote(str(value), safe="")
+    return encoded.replace("%2F", "%252F")
+
+
 from uuid import uuid4
 
 import httpx
@@ -250,7 +258,9 @@ async def _resolve_workflow_id(base_url: str, workflow_id_or_name: Union[int, st
     # TODO(dmu) LOW: Should we warn user here to avoid using workflow names in favor of workflow id?
     async with _make_httpx_client() as client:
         # TODO(dmu) MEDIUM: Generalize the way we make async calls to PromptLayer API and reuse it everywhere
-        response = await client.get(f"{base_url}/workflows/{workflow_id_or_name}", headers=headers)
+        response = await client.get(
+            f"{base_url}/workflows/{_quote_api_path_segment(workflow_id_or_name)}", headers=headers
+        )
         if response.status_code != 200:
             raise_on_bad_response(response, "PromptLayer had the following error while resolving workflow")
 
@@ -1588,7 +1598,7 @@ def get_prompt_template(
         if params:
             json_body = {**json_body, **params}
         response = _get_requests_session().post(
-            f"{base_url}/prompt-templates/{quote(prompt_name, safe='')}",
+            f"{base_url}/prompt-templates/{_quote_api_path_segment(prompt_name)}",
             headers={"X-API-KEY": api_key},
             json=json_body,
         )
@@ -1640,7 +1650,7 @@ async def aget_prompt_template(
             json_body.update(params)
         async with _make_httpx_client() as client:
             response = await client.post(
-                f"{base_url}/prompt-templates/{quote(prompt_name, safe='')}",
+                f"{base_url}/prompt-templates/{_quote_api_path_segment(prompt_name)}",
                 headers={"X-API-KEY": api_key},
                 json=json_body,
             )


### PR DESCRIPTION
## Problem

Prompt names and workflow names containing slashes (e.g. `feature1/resolve_problem_2`) cause **404 Not Found** errors because the slash is interpreted as a URL path separator.

Single URL encoding (`%2F`) doesn't work because PromptLayer's edge/proxy stack decodes it back to `/` before routing.

## Fix

Add `_quote_api_path_segment()` which double-encodes slashes (`%2F` → `%252F`) so they survive one decode pass by the proxy.

## Changes

- `promptlayer/utils.py`: Add `_quote_api_path_segment()` helper, update 3 URL constructions:
  - `_resolve_workflow_id()` — was using raw `workflow_id_or_name`
  - `get_prompt_template()` — was using `quote(name, safe='')`
  - `aget_prompt_template()` — was using `quote(name, safe='')`

## Testing

Verified that:
- `_quote_api_path_segment('simple')` → `simple`
- `_quote_api_path_segment('feature1/resolve')` → `feature1%252Fresolve`
- Integer IDs pass through unchanged

Fixes #254