### PR TITLE
Add table scorecard SDK clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+
+- Added public table scorecard APIs under `client.tables.sheets.scorecards`.
+- Existing `/score` compatibility types now allow scorecard fallback and piggyback recalculation responses.
+- Legacy score configuration deletion is not automatic during migration; `delete_legacy_score` defaults to `False`.

--- a/README.md
+++ b/README.md
@@ -131,9 +131,78 @@ The main resources surfaced by `PromptLayer` and `AsyncPromptLayer` are:
 | `client.group` | Group creation for organizing related requests. |
 | `client.traceable()` | Decorator for tracing your own functions and sending those spans to PromptLayer when tracing is enabled. |
 | `client.skills` | Skill collection pull, create, publish, and update operations. |
+| `client.tables.sheets.scorecards` | Table scorecard configuration, migration, recalculation, and row-level result retrieval. |
 | `client.openai` and `client.anthropic` | Provider proxies that wrap those SDKs and log requests to PromptLayer. |
 
 Note: When tracing is enabled, spans are exported to PromptLayer using OpenTelemetry.
+
+## Table Scorecards
+
+New scorecard APIs are preferred for new table scoring workflows. Legacy `/score` endpoints remain supported for existing integrations. If both a legacy score configuration and a scorecard exist on the same sheet, `/score` continues to return legacy score behavior; use the `/scorecard` endpoints through `client.tables.sheets.scorecards` to access scorecard state and results.
+
+Configure a scorecard:
+
+```python
+await client.tables.sheets.scorecards.configure(
+    table_id,
+    sheet_id,
+    {
+        "name": "Quality Scorecard",
+        "evaluated_column_ids": [],
+        "aggregation": {
+            "method": "weighted_mean",
+            "required_step_failure_behavior": "fail",
+            "pass_threshold": 0.8,
+            "warn_threshold": 0.6,
+        },
+        "steps": [],
+    },
+)
+```
+
+Migrate a legacy score safely. `delete_legacy_score` defaults to `False`, so migration does not remove legacy score configuration unless you explicitly request it:
+
+```python
+await client.tables.sheets.scorecards.migrate_legacy_score(
+    table_id,
+    sheet_id,
+    {"delete_legacy_score": False},
+)
+```
+
+Recalculate and fetch the calculation:
+
+```python
+run = await client.tables.sheets.scorecards.recalculate(table_id, sheet_id)
+
+result = await client.tables.sheets.scorecards.get_calculation(
+    table_id,
+    sheet_id,
+    run["calculation_id"],
+)
+```
+
+Fetch row breakdowns:
+
+```python
+rows = await client.tables.sheets.scorecards.list_rows(
+    table_id,
+    sheet_id,
+    {
+        "calculation_id": run["calculation_id"],
+        "verdict": "fail",
+    },
+)
+
+row = await client.tables.sheets.scorecards.get_row(
+    table_id,
+    sheet_id,
+    0,
+    {"calculation_id": run["calculation_id"]},
+)
+```
+
+Migration caveat: custom legacy scoring cannot be automatically converted into scorecard criteria. Review migrated criteria before relying on scorecard results in production.
 
 ## Integration Modules
 

--- a/promptlayer/promptlayer.py
+++ b/promptlayer/promptlayer.py
@@ -12,6 +12,7 @@ from promptlayer.promptlayer_base import PromptLayerBase
 from promptlayer.promptlayer_mixins import PromptLayerMixin
 from promptlayer.skills import AsyncSkillManager, SkillManager
 from promptlayer.streaming import astream_response, stream_response
+from promptlayer.tables import AsyncTableManager, TableManager
 from promptlayer.template_cache import PromptTemplateCache
 from promptlayer.templates import AsyncTemplateManager, TemplateManager
 from promptlayer.track import AsyncTrackManager, TrackManager
@@ -79,6 +80,7 @@ class PromptLayer(PromptLayerMixin):
         cache = PromptTemplateCache(cache_ttl_seconds) if cache_ttl_seconds else None
         self.templates = TemplateManager(api_key, self.base_url, self.throw_on_error, cache=cache)
         self.skills = SkillManager(api_key, self.base_url, self.throw_on_error)
+        self.tables = TableManager(api_key, self.base_url, self.throw_on_error)
         self.group = GroupManager(api_key, self.base_url, self.throw_on_error)
         self.tracer_provider, self.tracer = self._initialize_tracer(
             api_key, self.base_url, self.throw_on_error, enable_tracing
@@ -467,6 +469,7 @@ class AsyncPromptLayer(PromptLayerMixin):
         cache = PromptTemplateCache(cache_ttl_seconds) if cache_ttl_seconds else None
         self.templates = AsyncTemplateManager(api_key, self.base_url, self.throw_on_error, cache=cache)
         self.skills = AsyncSkillManager(api_key, self.base_url, self.throw_on_error)
+        self.tables = AsyncTableManager(api_key, self.base_url, self.throw_on_error)
         self.group = AsyncGroupManager(api_key, self.base_url, self.throw_on_error)
         self.tracer_provider, self.tracer = self._initialize_tracer(
             api_key, self.base_url, self.throw_on_error, enable_tracing

--- a/promptlayer/tables/__init__.py
+++ b/promptlayer/tables/__init__.py
@@ -1,0 +1,70 @@
+from promptlayer.tables.scorecards import (
+    AsyncScorecardManager,
+    ScorecardManager,
+    aconfigure_scorecard,
+    acancel_scorecard_calculation,
+    adelete_scorecard,
+    aget_scorecard,
+    aget_scorecard_calculation,
+    aget_scorecard_row,
+    alist_scorecard_rows,
+    amigrate_legacy_score,
+    arecalculate_scorecard,
+    cancel_scorecard_calculation,
+    configure_scorecard,
+    delete_scorecard,
+    get_scorecard,
+    get_scorecard_calculation,
+    get_scorecard_row,
+    list_scorecard_rows,
+    migrate_legacy_score,
+    recalculate_scorecard,
+)
+
+
+class SheetManager:
+    def __init__(self, api_key: str, base_url: str, throw_on_error: bool):
+        self.scorecards: ScorecardManager = ScorecardManager(api_key, base_url, throw_on_error)
+
+
+class TableManager:
+    def __init__(self, api_key: str, base_url: str, throw_on_error: bool):
+        self.sheets: SheetManager = SheetManager(api_key, base_url, throw_on_error)
+
+
+class AsyncSheetManager:
+    def __init__(self, api_key: str, base_url: str, throw_on_error: bool):
+        self.scorecards: AsyncScorecardManager = AsyncScorecardManager(api_key, base_url, throw_on_error)
+
+
+class AsyncTableManager:
+    def __init__(self, api_key: str, base_url: str, throw_on_error: bool):
+        self.sheets: AsyncSheetManager = AsyncSheetManager(api_key, base_url, throw_on_error)
+
+
+__all__ = [
+    "TableManager",
+    "AsyncTableManager",
+    "SheetManager",
+    "AsyncSheetManager",
+    "ScorecardManager",
+    "AsyncScorecardManager",
+    "get_scorecard",
+    "aget_scorecard",
+    "configure_scorecard",
+    "aconfigure_scorecard",
+    "delete_scorecard",
+    "adelete_scorecard",
+    "migrate_legacy_score",
+    "amigrate_legacy_score",
+    "recalculate_scorecard",
+    "arecalculate_scorecard",
+    "cancel_scorecard_calculation",
+    "acancel_scorecard_calculation",
+    "get_scorecard_calculation",
+    "aget_scorecard_calculation",
+    "list_scorecard_rows",
+    "alist_scorecard_rows",
+    "get_scorecard_row",
+    "aget_scorecard_row",
+]

--- a/promptlayer/tables/__init__.py
+++ b/promptlayer/tables/__init__.py
@@ -1,8 +1,8 @@
 from promptlayer.tables.scorecards import (
     AsyncScorecardManager,
     ScorecardManager,
-    aconfigure_scorecard,
     acancel_scorecard_calculation,
+    aconfigure_scorecard,
     adelete_scorecard,
     aget_scorecard,
     aget_scorecard_calculation,

--- a/promptlayer/tables/scorecards.py
+++ b/promptlayer/tables/scorecards.py
@@ -14,6 +14,8 @@ from promptlayer.types.scorecard import (
     RecalculateScorecardRequest,
     ScorecardActionResponse,
     ScorecardCalculationResponse,
+    ScorecardCancelResponse,
+    ScorecardRecalculateResponse,
     ScorecardResponse,
     ScorecardRowResponse,
     ScorecardRowsResponse,
@@ -30,6 +32,8 @@ from promptlayer.utils import (
 JsonResponse = Union[
     ScorecardResponse,
     ScorecardActionResponse,
+    ScorecardRecalculateResponse,
+    ScorecardCancelResponse,
     ScorecardCalculationResponse,
     ScorecardRowsResponse,
     ScorecardRowResponse,
@@ -172,7 +176,7 @@ def configure_scorecard(
     body: ConfigureScorecardRequest,
 ) -> Union[ScorecardResponse, None]:
     return _sync_request(
-        "put",
+        "patch",
         api_key,
         base_url,
         throw_on_error,
@@ -192,7 +196,7 @@ async def aconfigure_scorecard(
     body: ConfigureScorecardRequest,
 ) -> Union[ScorecardResponse, None]:
     return await _async_request(
-        "put",
+        "patch",
         api_key,
         base_url,
         throw_on_error,
@@ -288,7 +292,7 @@ def recalculate_scorecard(
     table_id: Union[str, int],
     sheet_id: Union[str, int],
     body: Union[RecalculateScorecardRequest, None] = None,
-) -> Union[ScorecardActionResponse, None]:
+) -> Union[ScorecardRecalculateResponse, None]:
     return _sync_request(
         "post",
         api_key,
@@ -298,6 +302,7 @@ def recalculate_scorecard(
         sheet_id,
         parts=("recalculate",),
         json=body or {},
+        success_status=202,
         error_context="PromptLayer had the following error while recalculating your scorecard",
     )
 
@@ -309,7 +314,7 @@ async def arecalculate_scorecard(
     table_id: Union[str, int],
     sheet_id: Union[str, int],
     body: Union[RecalculateScorecardRequest, None] = None,
-) -> Union[ScorecardActionResponse, None]:
+) -> Union[ScorecardRecalculateResponse, None]:
     return await _async_request(
         "post",
         api_key,
@@ -319,6 +324,7 @@ async def arecalculate_scorecard(
         sheet_id,
         parts=("recalculate",),
         json=body or {},
+        success_status=202,
         error_context="PromptLayer had the following error while recalculating your scorecard",
     )
 
@@ -330,7 +336,7 @@ def cancel_scorecard_calculation(
     table_id: Union[str, int],
     sheet_id: Union[str, int],
     body: Union[CancelScorecardRequest, None] = None,
-) -> Union[ScorecardActionResponse, None]:
+) -> Union[ScorecardCancelResponse, None]:
     return _sync_request(
         "post",
         api_key,
@@ -351,7 +357,7 @@ async def acancel_scorecard_calculation(
     table_id: Union[str, int],
     sheet_id: Union[str, int],
     body: Union[CancelScorecardRequest, None] = None,
-) -> Union[ScorecardActionResponse, None]:
+) -> Union[ScorecardCancelResponse, None]:
     return await _async_request(
         "post",
         api_key,
@@ -521,7 +527,7 @@ class ScorecardManager:
         table_id: Union[str, int],
         sheet_id: Union[str, int],
         options: Union[RecalculateScorecardRequest, None] = None,
-    ) -> Union[ScorecardActionResponse, None]:
+    ) -> Union[ScorecardRecalculateResponse, None]:
         return recalculate_scorecard(self.api_key, self.base_url, self.throw_on_error, table_id, sheet_id, options)
 
     def cancel(
@@ -529,7 +535,7 @@ class ScorecardManager:
         table_id: Union[str, int],
         sheet_id: Union[str, int],
         options: Union[CancelScorecardRequest, None] = None,
-    ) -> Union[ScorecardActionResponse, None]:
+    ) -> Union[ScorecardCancelResponse, None]:
         return cancel_scorecard_calculation(
             self.api_key, self.base_url, self.throw_on_error, table_id, sheet_id, options
         )
@@ -593,7 +599,7 @@ class AsyncScorecardManager:
         table_id: Union[str, int],
         sheet_id: Union[str, int],
         options: Union[RecalculateScorecardRequest, None] = None,
-    ) -> Union[ScorecardActionResponse, None]:
+    ) -> Union[ScorecardRecalculateResponse, None]:
         return await arecalculate_scorecard(
             self.api_key, self.base_url, self.throw_on_error, table_id, sheet_id, options
         )
@@ -603,7 +609,7 @@ class AsyncScorecardManager:
         table_id: Union[str, int],
         sheet_id: Union[str, int],
         options: Union[CancelScorecardRequest, None] = None,
-    ) -> Union[ScorecardActionResponse, None]:
+    ) -> Union[ScorecardCancelResponse, None]:
         return await acancel_scorecard_calculation(
             self.api_key, self.base_url, self.throw_on_error, table_id, sheet_id, options
         )

--- a/promptlayer/tables/scorecards.py
+++ b/promptlayer/tables/scorecards.py
@@ -1,0 +1,635 @@
+from typing import Any, Dict, Union
+from urllib.parse import quote
+
+import httpx
+import requests
+
+from promptlayer import exceptions as _exceptions
+from promptlayer.types.scorecard import (
+    CancelScorecardRequest,
+    ConfigureScorecardRequest,
+    GetScorecardRowOptions,
+    ListScorecardRowsOptions,
+    MigrateLegacyScorecardRequest,
+    RecalculateScorecardRequest,
+    ScorecardActionResponse,
+    ScorecardCalculationResponse,
+    ScorecardResponse,
+    ScorecardRowResponse,
+    ScorecardRowsResponse,
+)
+from promptlayer.utils import (
+    _get_requests_session,
+    _make_httpx_client,
+    logger,
+    raise_on_bad_response,
+    retry_on_api_error,
+    warn_on_bad_response,
+)
+
+JsonResponse = Union[
+    ScorecardResponse,
+    ScorecardActionResponse,
+    ScorecardCalculationResponse,
+    ScorecardRowsResponse,
+    ScorecardRowResponse,
+    Dict[str, Any],
+]
+
+
+def _scorecard_endpoint(base_url: str, table_id: Union[str, int], sheet_id: Union[str, int], *parts: Any) -> str:
+    encoded_table_id = quote(str(table_id), safe="")
+    encoded_sheet_id = quote(str(sheet_id), safe="")
+    suffix = "/".join(quote(str(part), safe="") for part in parts if part is not None)
+    base = f"{base_url}/api/public/v2/tables/{encoded_table_id}/sheets/{encoded_sheet_id}/scorecard"
+    return f"{base}/{suffix}" if suffix else base
+
+
+def _handle_response(response, throw_on_error: bool, success_status: int, error_context: str) -> Any:
+    if response.status_code != success_status:
+        if throw_on_error:
+            raise_on_bad_response(response, error_context)
+        warn_on_bad_response(response, f"WARNING: {error_context}")
+        return None
+    if response.status_code == 204:
+        return {"success": True}
+    return response.json()
+
+
+@retry_on_api_error
+def _sync_request(
+    method: str,
+    api_key: str,
+    base_url: str,
+    throw_on_error: bool,
+    table_id: Union[str, int],
+    sheet_id: Union[str, int],
+    *,
+    parts=(),
+    params: Any = None,
+    json: Any = None,
+    success_status: int = 200,
+    error_context: str,
+) -> Any:
+    try:
+        request_method = getattr(_get_requests_session(), method)
+        response = request_method(
+            _scorecard_endpoint(base_url, table_id, sheet_id, *parts),
+            headers={"X-API-KEY": api_key},
+            params=params,
+            json=json,
+        )
+        return _handle_response(response, throw_on_error, success_status, error_context)
+    except requests.exceptions.RequestException as e:
+        if throw_on_error:
+            raise _exceptions.PromptLayerAPIConnectionError(
+                f"{error_context}: {e}",
+                response=None,
+                body=None,
+            ) from e
+        logger.warning(f"{error_context}: {e}")
+        return None
+
+
+@retry_on_api_error
+async def _async_request(
+    method: str,
+    api_key: str,
+    base_url: str,
+    throw_on_error: bool,
+    table_id: Union[str, int],
+    sheet_id: Union[str, int],
+    *,
+    parts=(),
+    params: Any = None,
+    json: Any = None,
+    success_status: int = 200,
+    error_context: str,
+) -> Any:
+    try:
+        async with _make_httpx_client() as client:
+            request_method = getattr(client, method)
+            response = await request_method(
+                _scorecard_endpoint(base_url, table_id, sheet_id, *parts),
+                headers={"X-API-KEY": api_key},
+                params=params,
+                json=json,
+            )
+        return _handle_response(response, throw_on_error, success_status, error_context)
+    except httpx.RequestError as e:
+        if throw_on_error:
+            raise _exceptions.PromptLayerAPIConnectionError(
+                f"{error_context}: {str(e)}",
+                response=None,
+                body=None,
+            ) from e
+        logger.warning(f"{error_context}: {e}")
+        return None
+
+
+def get_scorecard(
+    api_key: str,
+    base_url: str,
+    throw_on_error: bool,
+    table_id: Union[str, int],
+    sheet_id: Union[str, int],
+) -> Union[ScorecardResponse, None]:
+    return _sync_request(
+        "get",
+        api_key,
+        base_url,
+        throw_on_error,
+        table_id,
+        sheet_id,
+        error_context="PromptLayer had the following error while fetching your scorecard",
+    )
+
+
+async def aget_scorecard(
+    api_key: str,
+    base_url: str,
+    throw_on_error: bool,
+    table_id: Union[str, int],
+    sheet_id: Union[str, int],
+) -> Union[ScorecardResponse, None]:
+    return await _async_request(
+        "get",
+        api_key,
+        base_url,
+        throw_on_error,
+        table_id,
+        sheet_id,
+        error_context="PromptLayer had the following error while fetching your scorecard",
+    )
+
+
+def configure_scorecard(
+    api_key: str,
+    base_url: str,
+    throw_on_error: bool,
+    table_id: Union[str, int],
+    sheet_id: Union[str, int],
+    body: ConfigureScorecardRequest,
+) -> Union[ScorecardResponse, None]:
+    return _sync_request(
+        "put",
+        api_key,
+        base_url,
+        throw_on_error,
+        table_id,
+        sheet_id,
+        json=body,
+        error_context="PromptLayer had the following error while configuring your scorecard",
+    )
+
+
+async def aconfigure_scorecard(
+    api_key: str,
+    base_url: str,
+    throw_on_error: bool,
+    table_id: Union[str, int],
+    sheet_id: Union[str, int],
+    body: ConfigureScorecardRequest,
+) -> Union[ScorecardResponse, None]:
+    return await _async_request(
+        "put",
+        api_key,
+        base_url,
+        throw_on_error,
+        table_id,
+        sheet_id,
+        json=body,
+        error_context="PromptLayer had the following error while configuring your scorecard",
+    )
+
+
+def delete_scorecard(
+    api_key: str,
+    base_url: str,
+    throw_on_error: bool,
+    table_id: Union[str, int],
+    sheet_id: Union[str, int],
+) -> Union[Dict[str, Any], None]:
+    return _sync_request(
+        "delete",
+        api_key,
+        base_url,
+        throw_on_error,
+        table_id,
+        sheet_id,
+        error_context="PromptLayer had the following error while deleting your scorecard",
+    )
+
+
+async def adelete_scorecard(
+    api_key: str,
+    base_url: str,
+    throw_on_error: bool,
+    table_id: Union[str, int],
+    sheet_id: Union[str, int],
+) -> Union[Dict[str, Any], None]:
+    return await _async_request(
+        "delete",
+        api_key,
+        base_url,
+        throw_on_error,
+        table_id,
+        sheet_id,
+        error_context="PromptLayer had the following error while deleting your scorecard",
+    )
+
+
+def migrate_legacy_score(
+    api_key: str,
+    base_url: str,
+    throw_on_error: bool,
+    table_id: Union[str, int],
+    sheet_id: Union[str, int],
+    body: Union[MigrateLegacyScorecardRequest, None] = None,
+) -> Union[ScorecardActionResponse, None]:
+    return _sync_request(
+        "post",
+        api_key,
+        base_url,
+        throw_on_error,
+        table_id,
+        sheet_id,
+        parts=("migrate-legacy-score",),
+        json=body or {},
+        error_context="PromptLayer had the following error while migrating your legacy score",
+    )
+
+
+async def amigrate_legacy_score(
+    api_key: str,
+    base_url: str,
+    throw_on_error: bool,
+    table_id: Union[str, int],
+    sheet_id: Union[str, int],
+    body: Union[MigrateLegacyScorecardRequest, None] = None,
+) -> Union[ScorecardActionResponse, None]:
+    return await _async_request(
+        "post",
+        api_key,
+        base_url,
+        throw_on_error,
+        table_id,
+        sheet_id,
+        parts=("migrate-legacy-score",),
+        json=body or {},
+        error_context="PromptLayer had the following error while migrating your legacy score",
+    )
+
+
+def recalculate_scorecard(
+    api_key: str,
+    base_url: str,
+    throw_on_error: bool,
+    table_id: Union[str, int],
+    sheet_id: Union[str, int],
+    body: Union[RecalculateScorecardRequest, None] = None,
+) -> Union[ScorecardActionResponse, None]:
+    return _sync_request(
+        "post",
+        api_key,
+        base_url,
+        throw_on_error,
+        table_id,
+        sheet_id,
+        parts=("recalculate",),
+        json=body or {},
+        error_context="PromptLayer had the following error while recalculating your scorecard",
+    )
+
+
+async def arecalculate_scorecard(
+    api_key: str,
+    base_url: str,
+    throw_on_error: bool,
+    table_id: Union[str, int],
+    sheet_id: Union[str, int],
+    body: Union[RecalculateScorecardRequest, None] = None,
+) -> Union[ScorecardActionResponse, None]:
+    return await _async_request(
+        "post",
+        api_key,
+        base_url,
+        throw_on_error,
+        table_id,
+        sheet_id,
+        parts=("recalculate",),
+        json=body or {},
+        error_context="PromptLayer had the following error while recalculating your scorecard",
+    )
+
+
+def cancel_scorecard_calculation(
+    api_key: str,
+    base_url: str,
+    throw_on_error: bool,
+    table_id: Union[str, int],
+    sheet_id: Union[str, int],
+    body: Union[CancelScorecardRequest, None] = None,
+) -> Union[ScorecardActionResponse, None]:
+    return _sync_request(
+        "post",
+        api_key,
+        base_url,
+        throw_on_error,
+        table_id,
+        sheet_id,
+        parts=("cancel",),
+        json=body or {},
+        error_context="PromptLayer had the following error while cancelling your scorecard calculation",
+    )
+
+
+async def acancel_scorecard_calculation(
+    api_key: str,
+    base_url: str,
+    throw_on_error: bool,
+    table_id: Union[str, int],
+    sheet_id: Union[str, int],
+    body: Union[CancelScorecardRequest, None] = None,
+) -> Union[ScorecardActionResponse, None]:
+    return await _async_request(
+        "post",
+        api_key,
+        base_url,
+        throw_on_error,
+        table_id,
+        sheet_id,
+        parts=("cancel",),
+        json=body or {},
+        error_context="PromptLayer had the following error while cancelling your scorecard calculation",
+    )
+
+
+def get_scorecard_calculation(
+    api_key: str,
+    base_url: str,
+    throw_on_error: bool,
+    table_id: Union[str, int],
+    sheet_id: Union[str, int],
+    calculation_id: str,
+) -> Union[ScorecardCalculationResponse, None]:
+    return _sync_request(
+        "get",
+        api_key,
+        base_url,
+        throw_on_error,
+        table_id,
+        sheet_id,
+        parts=("calculations", calculation_id),
+        error_context="PromptLayer had the following error while fetching your scorecard calculation",
+    )
+
+
+async def aget_scorecard_calculation(
+    api_key: str,
+    base_url: str,
+    throw_on_error: bool,
+    table_id: Union[str, int],
+    sheet_id: Union[str, int],
+    calculation_id: str,
+) -> Union[ScorecardCalculationResponse, None]:
+    return await _async_request(
+        "get",
+        api_key,
+        base_url,
+        throw_on_error,
+        table_id,
+        sheet_id,
+        parts=("calculations", calculation_id),
+        error_context="PromptLayer had the following error while fetching your scorecard calculation",
+    )
+
+
+def list_scorecard_rows(
+    api_key: str,
+    base_url: str,
+    throw_on_error: bool,
+    table_id: Union[str, int],
+    sheet_id: Union[str, int],
+    options: Union[ListScorecardRowsOptions, None] = None,
+) -> Union[ScorecardRowsResponse, None]:
+    return _sync_request(
+        "get",
+        api_key,
+        base_url,
+        throw_on_error,
+        table_id,
+        sheet_id,
+        parts=("rows",),
+        params=options,
+        error_context="PromptLayer had the following error while listing your scorecard rows",
+    )
+
+
+async def alist_scorecard_rows(
+    api_key: str,
+    base_url: str,
+    throw_on_error: bool,
+    table_id: Union[str, int],
+    sheet_id: Union[str, int],
+    options: Union[ListScorecardRowsOptions, None] = None,
+) -> Union[ScorecardRowsResponse, None]:
+    return await _async_request(
+        "get",
+        api_key,
+        base_url,
+        throw_on_error,
+        table_id,
+        sheet_id,
+        parts=("rows",),
+        params=options,
+        error_context="PromptLayer had the following error while listing your scorecard rows",
+    )
+
+
+def get_scorecard_row(
+    api_key: str,
+    base_url: str,
+    throw_on_error: bool,
+    table_id: Union[str, int],
+    sheet_id: Union[str, int],
+    row_index: int,
+    options: Union[GetScorecardRowOptions, None] = None,
+) -> Union[ScorecardRowResponse, None]:
+    return _sync_request(
+        "get",
+        api_key,
+        base_url,
+        throw_on_error,
+        table_id,
+        sheet_id,
+        parts=("rows", row_index),
+        params=options,
+        error_context="PromptLayer had the following error while fetching your scorecard row",
+    )
+
+
+async def aget_scorecard_row(
+    api_key: str,
+    base_url: str,
+    throw_on_error: bool,
+    table_id: Union[str, int],
+    sheet_id: Union[str, int],
+    row_index: int,
+    options: Union[GetScorecardRowOptions, None] = None,
+) -> Union[ScorecardRowResponse, None]:
+    return await _async_request(
+        "get",
+        api_key,
+        base_url,
+        throw_on_error,
+        table_id,
+        sheet_id,
+        parts=("rows", row_index),
+        params=options,
+        error_context="PromptLayer had the following error while fetching your scorecard row",
+    )
+
+
+class ScorecardManager:
+    def __init__(self, api_key: str, base_url: str, throw_on_error: bool):
+        self.api_key = api_key
+        self.base_url = base_url
+        self.throw_on_error = throw_on_error
+
+    def get(self, table_id: Union[str, int], sheet_id: Union[str, int]) -> Union[ScorecardResponse, None]:
+        return get_scorecard(self.api_key, self.base_url, self.throw_on_error, table_id, sheet_id)
+
+    def configure(
+        self, table_id: Union[str, int], sheet_id: Union[str, int], body: ConfigureScorecardRequest
+    ) -> Union[ScorecardResponse, None]:
+        return configure_scorecard(self.api_key, self.base_url, self.throw_on_error, table_id, sheet_id, body)
+
+    def delete(self, table_id: Union[str, int], sheet_id: Union[str, int]) -> Union[Dict[str, Any], None]:
+        return delete_scorecard(self.api_key, self.base_url, self.throw_on_error, table_id, sheet_id)
+
+    def migrate_legacy_score(
+        self,
+        table_id: Union[str, int],
+        sheet_id: Union[str, int],
+        options: Union[MigrateLegacyScorecardRequest, None] = None,
+    ) -> Union[ScorecardActionResponse, None]:
+        return migrate_legacy_score(self.api_key, self.base_url, self.throw_on_error, table_id, sheet_id, options)
+
+    def recalculate(
+        self,
+        table_id: Union[str, int],
+        sheet_id: Union[str, int],
+        options: Union[RecalculateScorecardRequest, None] = None,
+    ) -> Union[ScorecardActionResponse, None]:
+        return recalculate_scorecard(self.api_key, self.base_url, self.throw_on_error, table_id, sheet_id, options)
+
+    def cancel(
+        self,
+        table_id: Union[str, int],
+        sheet_id: Union[str, int],
+        options: Union[CancelScorecardRequest, None] = None,
+    ) -> Union[ScorecardActionResponse, None]:
+        return cancel_scorecard_calculation(
+            self.api_key, self.base_url, self.throw_on_error, table_id, sheet_id, options
+        )
+
+    def get_calculation(
+        self, table_id: Union[str, int], sheet_id: Union[str, int], calculation_id: str
+    ) -> Union[ScorecardCalculationResponse, None]:
+        return get_scorecard_calculation(
+            self.api_key, self.base_url, self.throw_on_error, table_id, sheet_id, calculation_id
+        )
+
+    def list_rows(
+        self,
+        table_id: Union[str, int],
+        sheet_id: Union[str, int],
+        options: Union[ListScorecardRowsOptions, None] = None,
+    ) -> Union[ScorecardRowsResponse, None]:
+        return list_scorecard_rows(self.api_key, self.base_url, self.throw_on_error, table_id, sheet_id, options)
+
+    def get_row(
+        self,
+        table_id: Union[str, int],
+        sheet_id: Union[str, int],
+        row_index: int,
+        options: Union[GetScorecardRowOptions, None] = None,
+    ) -> Union[ScorecardRowResponse, None]:
+        return get_scorecard_row(
+            self.api_key, self.base_url, self.throw_on_error, table_id, sheet_id, row_index, options
+        )
+
+
+class AsyncScorecardManager:
+    def __init__(self, api_key: str, base_url: str, throw_on_error: bool):
+        self.api_key = api_key
+        self.base_url = base_url
+        self.throw_on_error = throw_on_error
+
+    async def get(self, table_id: Union[str, int], sheet_id: Union[str, int]) -> Union[ScorecardResponse, None]:
+        return await aget_scorecard(self.api_key, self.base_url, self.throw_on_error, table_id, sheet_id)
+
+    async def configure(
+        self, table_id: Union[str, int], sheet_id: Union[str, int], body: ConfigureScorecardRequest
+    ) -> Union[ScorecardResponse, None]:
+        return await aconfigure_scorecard(self.api_key, self.base_url, self.throw_on_error, table_id, sheet_id, body)
+
+    async def delete(self, table_id: Union[str, int], sheet_id: Union[str, int]) -> Union[Dict[str, Any], None]:
+        return await adelete_scorecard(self.api_key, self.base_url, self.throw_on_error, table_id, sheet_id)
+
+    async def migrate_legacy_score(
+        self,
+        table_id: Union[str, int],
+        sheet_id: Union[str, int],
+        options: Union[MigrateLegacyScorecardRequest, None] = None,
+    ) -> Union[ScorecardActionResponse, None]:
+        return await amigrate_legacy_score(
+            self.api_key, self.base_url, self.throw_on_error, table_id, sheet_id, options
+        )
+
+    async def recalculate(
+        self,
+        table_id: Union[str, int],
+        sheet_id: Union[str, int],
+        options: Union[RecalculateScorecardRequest, None] = None,
+    ) -> Union[ScorecardActionResponse, None]:
+        return await arecalculate_scorecard(
+            self.api_key, self.base_url, self.throw_on_error, table_id, sheet_id, options
+        )
+
+    async def cancel(
+        self,
+        table_id: Union[str, int],
+        sheet_id: Union[str, int],
+        options: Union[CancelScorecardRequest, None] = None,
+    ) -> Union[ScorecardActionResponse, None]:
+        return await acancel_scorecard_calculation(
+            self.api_key, self.base_url, self.throw_on_error, table_id, sheet_id, options
+        )
+
+    async def get_calculation(
+        self, table_id: Union[str, int], sheet_id: Union[str, int], calculation_id: str
+    ) -> Union[ScorecardCalculationResponse, None]:
+        return await aget_scorecard_calculation(
+            self.api_key, self.base_url, self.throw_on_error, table_id, sheet_id, calculation_id
+        )
+
+    async def list_rows(
+        self,
+        table_id: Union[str, int],
+        sheet_id: Union[str, int],
+        options: Union[ListScorecardRowsOptions, None] = None,
+    ) -> Union[ScorecardRowsResponse, None]:
+        return await alist_scorecard_rows(self.api_key, self.base_url, self.throw_on_error, table_id, sheet_id, options)
+
+    async def get_row(
+        self,
+        table_id: Union[str, int],
+        sheet_id: Union[str, int],
+        row_index: int,
+        options: Union[GetScorecardRowOptions, None] = None,
+    ) -> Union[ScorecardRowResponse, None]:
+        return await aget_scorecard_row(
+            self.api_key, self.base_url, self.throw_on_error, table_id, sheet_id, row_index, options
+        )

--- a/promptlayer/types/__init__.py
+++ b/promptlayer/types/__init__.py
@@ -1,4 +1,4 @@
-from . import prompt_template, skill
+from . import prompt_template, scorecard, skill
 from .request_log import RequestLog
 
-__all__ = ["prompt_template", "skill", "RequestLog"]
+__all__ = ["prompt_template", "scorecard", "skill", "RequestLog"]

--- a/promptlayer/types/scorecard.py
+++ b/promptlayer/types/scorecard.py
@@ -5,12 +5,19 @@ from typing_extensions import NotRequired, Required
 ScoreVerdict = Literal["pass", "warn", "fail", "error", "skipped", "unknown"]
 ScorecardStatus = Literal["needs_setup", "ready", "queued", "running", "completed", "stale", "failed"]
 ScorecardCalculationStatus = Literal["queued", "running", "completed", "failed", "cancelled"]
+# Public scorecard payloads use uppercase primitive types; lowercase values are retained for
+# compatibility with the initial unreleased SDK draft shipped in this PR branch.
 ScorecardPrimitiveType = Literal[
     "BOOLEAN",
     "NUMBER",
     "CATEGORICAL",
     "TEXT",
     "JSON",
+    "boolean",
+    "number",
+    "categorical",
+    "text",
+    "json",
 ]
 ScorecardStaleState = Literal["fresh", "stale", "missing", "unknown"]
 
@@ -51,13 +58,17 @@ class CriterionSummary(TypedDict, total=False):
 class ScorecardStep(TypedDict, total=False):
     id: NotRequired[str]
     title: Required[str]
+    # Public API uses `title`; retain `name` for compatibility with the initial unreleased SDK draft.
+    name: NotRequired[str]
     description: NotRequired[str]
     evaluator_id: NotRequired[str]
     primitive_type: NotRequired[ScorecardPrimitiveType]
     required: NotRequired[bool]
     weight: NotRequired[float]
     thresholds: NotRequired[ScorecardThresholds]
+    # Backend scorecard steps serialize provider-specific primitive settings under `primitive_config`.
     primitive_config: NotRequired[Dict[str, Any]]
+    # Backend scorecard steps serialize aggregation/adaptation settings under `score_adapter`.
     score_adapter: NotRequired[Dict[str, Any]]
     config: NotRequired[Dict[str, Any]]
 

--- a/promptlayer/types/scorecard.py
+++ b/promptlayer/types/scorecard.py
@@ -11,11 +11,6 @@ ScorecardPrimitiveType = Literal[
     "CATEGORICAL",
     "TEXT",
     "JSON",
-    "boolean",
-    "number",
-    "categorical",
-    "text",
-    "json",
 ]
 ScorecardStaleState = Literal["fresh", "stale", "missing", "unknown"]
 
@@ -56,7 +51,6 @@ class CriterionSummary(TypedDict, total=False):
 class ScorecardStep(TypedDict, total=False):
     id: NotRequired[str]
     title: Required[str]
-    name: NotRequired[str]
     description: NotRequired[str]
     evaluator_id: NotRequired[str]
     primitive_type: NotRequired[ScorecardPrimitiveType]

--- a/promptlayer/types/scorecard.py
+++ b/promptlayer/types/scorecard.py
@@ -72,7 +72,8 @@ class CriterionSummary(TypedDict, total=False):
 class ScorecardStep(TypedDict, total=False):
     id: NotRequired[str]
     title: Required[str]
-    # Public API uses `title`; retain `name` for compatibility with the initial unreleased SDK draft.
+    # Public API uses `title`; use that going forward. `name` is retained only for compatibility
+    # with the initial unreleased SDK draft and may be removed in a future version.
     name: NotRequired[str]
     description: NotRequired[str]
     evaluator_id: NotRequired[str]
@@ -223,8 +224,8 @@ class ScorecardRowsResponse(TypedDict, total=False):
 
 class ScorecardRowResponse(ScorecardRowBreakdown, total=False):
     success: Required[bool]
-    # Public API flattens row fields at the top level; retain `row` for compatibility with the
-    # initial unreleased SDK draft structure.
+    # Public API returns row fields at the top level; clients should prefer those fields. The
+    # nested `row` shape is retained only for compatibility with the initial unreleased SDK draft.
     row: NotRequired[ScorecardRowBreakdown]
 
 

--- a/promptlayer/types/scorecard.py
+++ b/promptlayer/types/scorecard.py
@@ -1,11 +1,22 @@
 from typing import Any, Dict, List, Literal, Optional, TypedDict, Union
 
-from typing_extensions import Required
+from typing_extensions import NotRequired, Required
 
 ScoreVerdict = Literal["pass", "warn", "fail", "error", "skipped", "unknown"]
-ScorecardStatus = Literal["active", "draft", "disabled", "deleted"]
+ScorecardStatus = Literal["needs_setup", "ready", "queued", "running", "completed", "stale", "failed"]
 ScorecardCalculationStatus = Literal["queued", "running", "completed", "failed", "cancelled"]
-ScorecardPrimitiveType = Literal["boolean", "number", "categorical", "text", "json"]
+ScorecardPrimitiveType = Literal[
+    "BOOLEAN",
+    "NUMBER",
+    "CATEGORICAL",
+    "TEXT",
+    "JSON",
+    "boolean",
+    "number",
+    "categorical",
+    "text",
+    "json",
+]
 ScorecardStaleState = Literal["fresh", "stale", "missing", "unknown"]
 
 
@@ -43,15 +54,18 @@ class CriterionSummary(TypedDict, total=False):
 
 
 class ScorecardStep(TypedDict, total=False):
-    id: Optional[str]
-    name: Required[str]
-    description: Optional[str]
-    evaluator_id: Optional[str]
-    primitive_type: Optional[ScorecardPrimitiveType]
-    required: Optional[bool]
-    weight: Optional[float]
-    thresholds: Optional[ScorecardThresholds]
-    config: Dict[str, Any]
+    id: NotRequired[str]
+    title: Required[str]
+    name: NotRequired[str]
+    description: NotRequired[str]
+    evaluator_id: NotRequired[str]
+    primitive_type: NotRequired[ScorecardPrimitiveType]
+    required: NotRequired[bool]
+    weight: NotRequired[float]
+    thresholds: NotRequired[ScorecardThresholds]
+    primitive_config: NotRequired[Dict[str, Any]]
+    score_adapter: NotRequired[Dict[str, Any]]
+    config: NotRequired[Dict[str, Any]]
 
 
 class ScorecardDriftSummary(TypedDict, total=False):
@@ -84,34 +98,35 @@ class ScorecardCalculation(TypedDict, total=False):
     table_id: Required[Union[str, int]]
     sheet_id: Required[Union[str, int]]
     status: Required[ScorecardCalculationStatus]
-    version: Optional[int]
-    score: Optional[float]
-    verdict: Optional[ScoreVerdict]
-    row_count: Optional[int]
-    completed_row_count: Optional[int]
-    failed_row_count: Optional[int]
-    error_message: Optional[str]
-    started_at: Optional[str]
-    completed_at: Optional[str]
-    created_at: Optional[str]
-    updated_at: Optional[str]
+    version: NotRequired[int]
+    aggregate_score: NotRequired[float]
+    aggregate_verdict: NotRequired[ScoreVerdict]
+    criterion_summaries: NotRequired[List[CriterionSummary]]
+    drift_summary: NotRequired[ScorecardDriftSummary]
+    row_count: NotRequired[int]
+    completed_row_count: NotRequired[int]
+    failed_row_count: NotRequired[int]
+    error_summary: NotRequired[Dict[str, Any]]
+    started_at: NotRequired[str]
+    completed_at: NotRequired[str]
+    created_at: NotRequired[str]
+    updated_at: NotRequired[str]
 
 
 class ScorecardRowSummary(TypedDict, total=False):
     row_index: Required[int]
-    calculation_id: Optional[str]
-    score: Optional[float]
-    verdict: Optional[ScoreVerdict]
-    stale_state: Optional[ScorecardStaleState]
-    criterion_summaries: List[CriterionSummary]
-    error_message: Optional[str]
+    calculation_id: NotRequired[str]
+    aggregate_score: NotRequired[float]
+    aggregate_verdict: NotRequired[ScoreVerdict]
+    step_results: NotRequired[Dict[str, Any]]
+    drift_summary: NotRequired[ScorecardDriftSummary]
+    stale_state: NotRequired[ScorecardStaleState]
+    error_summary: NotRequired[Dict[str, Any]]
 
 
 class ScorecardRowBreakdown(ScorecardRowSummary, total=False):
-    criteria: List[CriterionSummary]
-    evaluator_results: List[EvaluatorResult]
-    aggregate_result: Dict[str, Any]
-    row_data: Dict[str, Any]
+    criterion_summaries: NotRequired[List[CriterionSummary]]
+    row_data: NotRequired[Dict[str, Any]]
 
 
 class ConfigureScorecardRequest(TypedDict, total=False):
@@ -128,19 +143,19 @@ class MigrateLegacyScorecardRequest(TypedDict, total=False):
 
 class RecalculateScorecardRequest(TypedDict, total=False):
     row_indices: List[int]
-    force: bool
+    step_ids: List[str]
 
 
 class CancelScorecardRequest(TypedDict, total=False):
-    calculation_id: str
+    row_indices: List[int]
+    step_ids: List[str]
 
 
 class ListScorecardRowsOptions(TypedDict, total=False):
     calculation_id: str
     verdict: ScoreVerdict
-    stale_state: ScorecardStaleState
     limit: int
-    offset: int
+    cursor: str
 
 
 class GetScorecardRowOptions(TypedDict, total=False):
@@ -159,38 +174,61 @@ class ScorecardCalculationResponse(TypedDict, total=False):
 
 class ScorecardActionResponse(TypedDict, total=False):
     success: Required[bool]
-    calculation_id: Optional[str]
-    status: Optional[ScorecardCalculationStatus]
-    version: Optional[int]
-    scorecard: Optional[Scorecard]
-    calculation: Optional[ScorecardCalculation]
+    message: NotRequired[str]
+    scorecard: NotRequired[Scorecard]
+
+
+class ScorecardRecalculateResponse(TypedDict, total=False):
+    success: Required[bool]
+    calculation_id: Required[str]
+    status: Required[Literal["queued"]]
+    version: Required[int]
+
+
+class ScorecardCancelResponse(TypedDict, total=False):
+    success: Required[bool]
+    message: NotRequired[str]
+    scorecard: NotRequired[Scorecard]
+    cancelled_count: NotRequired[int]
+    execution_ids: NotRequired[List[str]]
+    calculation_id: NotRequired[str]
 
 
 class ScorecardRowsResponse(TypedDict, total=False):
     success: Required[bool]
+    calculation_id: NotRequired[str]
     rows: Required[List[ScorecardRowSummary]]
-    next_offset: Optional[int]
+    next_cursor: NotRequired[Optional[str]]
+    verdict_counts: NotRequired[Dict[str, int]]
 
 
-class ScorecardRowResponse(TypedDict, total=False):
+class ScorecardRowResponse(ScorecardRowBreakdown, total=False):
     success: Required[bool]
-    row: Required[ScorecardRowBreakdown]
 
 
-class LegacyScorecardAggregateResult(TypedDict):
+class LegacyScorecardAggregateResult(TypedDict, total=False):
     scorecard_id: Required[str]
     scorecard_calculation_id: Required[str]
+    aggregate_score: NotRequired[float]
+    aggregate_verdict: NotRequired[ScoreVerdict]
 
 
-class LegacyScorecardDetails(TypedDict):
+class LegacyScorecardDetails(TypedDict, total=False):
     aggregate_result: Required[LegacyScorecardAggregateResult]
+    aggregate: NotRequired[Dict[str, Any]]
+    per_column: NotRequired[Dict[str, Any]]
 
 
-class GetScoreScorecardCompatibilityResponse(TypedDict):
+class GetScoreScorecardCompatibilityResponse(TypedDict, total=False):
     score_type: Required[Literal["scorecard"]]
     scoring_type: Required[Literal["scorecard"]]
     score_configuration: Required[None]
     details: Required[LegacyScorecardDetails]
+    overall_score: NotRequired[float]
+    aggregate_score: NotRequired[float]
+    aggregate: NotRequired[Dict[str, Any]]
+    per_column: NotRequired[Dict[str, Any]]
+    status: NotRequired[str]
 
 
 class RecalculateScoreLegacyResponse(TypedDict, total=False):

--- a/promptlayer/types/scorecard.py
+++ b/promptlayer/types/scorecard.py
@@ -1,0 +1,210 @@
+from typing import Any, Dict, List, Literal, Optional, TypedDict, Union
+
+from typing_extensions import Required
+
+ScoreVerdict = Literal["pass", "warn", "fail", "error", "skipped", "unknown"]
+ScorecardStatus = Literal["active", "draft", "disabled", "deleted"]
+ScorecardCalculationStatus = Literal["queued", "running", "completed", "failed", "cancelled"]
+ScorecardPrimitiveType = Literal["boolean", "number", "categorical", "text", "json"]
+ScorecardStaleState = Literal["fresh", "stale", "missing", "unknown"]
+
+
+class ScorecardThresholds(TypedDict, total=False):
+    pass_threshold: Optional[float]
+    warn_threshold: Optional[float]
+
+
+class ScorecardAggregationConfig(ScorecardThresholds, total=False):
+    method: Required[str]
+    required_step_failure_behavior: Optional[str]
+    weights: Dict[str, float]
+
+
+class EvaluatorResult(TypedDict, total=False):
+    evaluator_id: Optional[str]
+    evaluator_name: Optional[str]
+    primitive_type: Optional[ScorecardPrimitiveType]
+    score: Optional[float]
+    value: Any
+    verdict: Optional[ScoreVerdict]
+    status: Optional[str]
+    error_message: Optional[str]
+    metadata: Dict[str, Any]
+
+
+class CriterionSummary(TypedDict, total=False):
+    criterion_id: Required[str]
+    name: Required[str]
+    score: Optional[float]
+    verdict: Optional[ScoreVerdict]
+    weight: Optional[float]
+    required: Optional[bool]
+    evaluator_result: Optional[EvaluatorResult]
+
+
+class ScorecardStep(TypedDict, total=False):
+    id: Optional[str]
+    name: Required[str]
+    description: Optional[str]
+    evaluator_id: Optional[str]
+    primitive_type: Optional[ScorecardPrimitiveType]
+    required: Optional[bool]
+    weight: Optional[float]
+    thresholds: Optional[ScorecardThresholds]
+    config: Dict[str, Any]
+
+
+class ScorecardDriftSummary(TypedDict, total=False):
+    stale_state: Optional[ScorecardStaleState]
+    stale_row_count: Optional[int]
+    total_row_count: Optional[int]
+    last_calculation_id: Optional[str]
+    last_calculated_at: Optional[str]
+
+
+class Scorecard(TypedDict, total=False):
+    id: Required[str]
+    table_id: Required[Union[str, int]]
+    sheet_id: Required[Union[str, int]]
+    name: Required[str]
+    status: Optional[ScorecardStatus]
+    evaluated_column_ids: List[Union[str, int]]
+    aggregation: Required[ScorecardAggregationConfig]
+    steps: Required[List[ScorecardStep]]
+    version: Optional[int]
+    thresholds: Optional[ScorecardThresholds]
+    drift_summary: Optional[ScorecardDriftSummary]
+    created_at: Optional[str]
+    updated_at: Optional[str]
+
+
+class ScorecardCalculation(TypedDict, total=False):
+    id: Required[str]
+    scorecard_id: Required[str]
+    table_id: Required[Union[str, int]]
+    sheet_id: Required[Union[str, int]]
+    status: Required[ScorecardCalculationStatus]
+    version: Optional[int]
+    score: Optional[float]
+    verdict: Optional[ScoreVerdict]
+    row_count: Optional[int]
+    completed_row_count: Optional[int]
+    failed_row_count: Optional[int]
+    error_message: Optional[str]
+    started_at: Optional[str]
+    completed_at: Optional[str]
+    created_at: Optional[str]
+    updated_at: Optional[str]
+
+
+class ScorecardRowSummary(TypedDict, total=False):
+    row_index: Required[int]
+    calculation_id: Optional[str]
+    score: Optional[float]
+    verdict: Optional[ScoreVerdict]
+    stale_state: Optional[ScorecardStaleState]
+    criterion_summaries: List[CriterionSummary]
+    error_message: Optional[str]
+
+
+class ScorecardRowBreakdown(ScorecardRowSummary, total=False):
+    criteria: List[CriterionSummary]
+    evaluator_results: List[EvaluatorResult]
+    aggregate_result: Dict[str, Any]
+    row_data: Dict[str, Any]
+
+
+class ConfigureScorecardRequest(TypedDict, total=False):
+    name: Required[str]
+    evaluated_column_ids: Required[List[Union[str, int]]]
+    aggregation: Required[ScorecardAggregationConfig]
+    steps: Required[List[ScorecardStep]]
+
+
+class MigrateLegacyScorecardRequest(TypedDict, total=False):
+    # Defaults to False so migrations do not remove legacy score configuration unless requested.
+    delete_legacy_score: bool
+
+
+class RecalculateScorecardRequest(TypedDict, total=False):
+    row_indices: List[int]
+    force: bool
+
+
+class CancelScorecardRequest(TypedDict, total=False):
+    calculation_id: str
+
+
+class ListScorecardRowsOptions(TypedDict, total=False):
+    calculation_id: str
+    verdict: ScoreVerdict
+    stale_state: ScorecardStaleState
+    limit: int
+    offset: int
+
+
+class GetScorecardRowOptions(TypedDict, total=False):
+    calculation_id: str
+
+
+class ScorecardResponse(TypedDict, total=False):
+    success: Required[bool]
+    scorecard: Required[Scorecard]
+
+
+class ScorecardCalculationResponse(TypedDict, total=False):
+    success: Required[bool]
+    calculation: Required[ScorecardCalculation]
+
+
+class ScorecardActionResponse(TypedDict, total=False):
+    success: Required[bool]
+    calculation_id: Optional[str]
+    status: Optional[ScorecardCalculationStatus]
+    version: Optional[int]
+    scorecard: Optional[Scorecard]
+    calculation: Optional[ScorecardCalculation]
+
+
+class ScorecardRowsResponse(TypedDict, total=False):
+    success: Required[bool]
+    rows: Required[List[ScorecardRowSummary]]
+    next_offset: Optional[int]
+
+
+class ScorecardRowResponse(TypedDict, total=False):
+    success: Required[bool]
+    row: Required[ScorecardRowBreakdown]
+
+
+class LegacyScorecardAggregateResult(TypedDict):
+    scorecard_id: Required[str]
+    scorecard_calculation_id: Required[str]
+
+
+class LegacyScorecardDetails(TypedDict):
+    aggregate_result: Required[LegacyScorecardAggregateResult]
+
+
+class GetScoreScorecardCompatibilityResponse(TypedDict):
+    score_type: Required[Literal["scorecard"]]
+    scoring_type: Required[Literal["scorecard"]]
+    score_configuration: Required[None]
+    details: Required[LegacyScorecardDetails]
+
+
+class RecalculateScoreLegacyResponse(TypedDict, total=False):
+    success: Required[bool]
+    score_configuration_id: Required[str]
+    status: Required[str]
+
+
+class RecalculateScoreScorecardResponse(TypedDict, total=False):
+    success: Required[bool]
+    score_source: Required[Literal["scorecard"]]
+    calculation_id: Required[str]
+    status: Required[Literal["queued"]]
+    version: Required[int]
+
+
+RecalculateScoreResponse = Union[RecalculateScoreLegacyResponse, RecalculateScoreScorecardResponse]

--- a/promptlayer/types/scorecard.py
+++ b/promptlayer/types/scorecard.py
@@ -3,7 +3,21 @@ from typing import Any, Dict, List, Literal, Optional, TypedDict, Union
 from typing_extensions import NotRequired, Required
 
 ScoreVerdict = Literal["pass", "warn", "fail", "error", "skipped", "unknown"]
-ScorecardStatus = Literal["needs_setup", "ready", "queued", "running", "completed", "stale", "failed"]
+# Public scorecards use lifecycle statuses like `needs_setup` and `ready`; the older draft values
+# are retained for compatibility with the initial unreleased SDK draft shipped in this PR branch.
+ScorecardStatus = Literal[
+    "needs_setup",
+    "ready",
+    "queued",
+    "running",
+    "completed",
+    "stale",
+    "failed",
+    "active",
+    "draft",
+    "disabled",
+    "deleted",
+]
 ScorecardCalculationStatus = Literal["queued", "running", "completed", "failed", "cancelled"]
 # Public scorecard payloads use uppercase primitive types; lowercase values are retained for
 # compatibility with the initial unreleased SDK draft shipped in this PR branch.
@@ -186,7 +200,7 @@ class ScorecardActionResponse(TypedDict, total=False):
 class ScorecardRecalculateResponse(TypedDict, total=False):
     success: Required[bool]
     calculation_id: Required[str]
-    status: Required[Literal["queued"]]
+    status: Required[ScorecardCalculationStatus]
     version: Required[int]
 
 
@@ -209,6 +223,9 @@ class ScorecardRowsResponse(TypedDict, total=False):
 
 class ScorecardRowResponse(ScorecardRowBreakdown, total=False):
     success: Required[bool]
+    # Public API flattens row fields at the top level; retain `row` for compatibility with the
+    # initial unreleased SDK draft structure.
+    row: NotRequired[ScorecardRowBreakdown]
 
 
 class LegacyScorecardAggregateResult(TypedDict, total=False):

--- a/tests/test_scorecards.py
+++ b/tests/test_scorecards.py
@@ -4,7 +4,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from promptlayer.tables import (
+    aconfigure_scorecard,
     aget_scorecard,
+    arecalculate_scorecard,
     configure_scorecard,
     delete_scorecard,
     get_scorecard,
@@ -57,7 +59,7 @@ def test_get_scorecard_sends_expected_request(promptlayer_api_key, base_url):
         assert response == payload
 
 
-def test_configure_scorecard_puts_body(promptlayer_api_key, base_url):
+def test_configure_scorecard_patches_body(promptlayer_api_key, base_url):
     body: ConfigureScorecardRequest = {
         "name": "Quality Scorecard",
         "evaluated_column_ids": [],
@@ -72,11 +74,11 @@ def test_configure_scorecard_puts_body(promptlayer_api_key, base_url):
     payload = {"success": True, "scorecard": {"id": "sc_1", **body}}
 
     with patch("promptlayer.tables.scorecards._get_requests_session") as mock_session:
-        mock_session.return_value.put.return_value = _mock_response(payload)
+        mock_session.return_value.patch.return_value = _mock_response(payload)
 
         response = configure_scorecard(promptlayer_api_key, base_url, True, TABLE_ID, SHEET_ID, body)
 
-        _assert_request(mock_session.return_value.put.call_args, base_url, promptlayer_api_key, json=body)
+        _assert_request(mock_session.return_value.patch.call_args, base_url, promptlayer_api_key, json=body)
         assert response == payload
 
 
@@ -100,11 +102,11 @@ def test_migrate_legacy_score_posts_options(promptlayer_api_key, base_url):
 
 
 def test_recalculate_scorecard_posts_options(promptlayer_api_key, base_url):
-    body: RecalculateScorecardRequest = {"row_indices": [0, 1], "force": True}
+    body: RecalculateScorecardRequest = {"row_indices": [0, 1], "step_ids": ["step_1"]}
     payload = {"success": True, "calculation_id": "calc_1", "status": "queued", "version": 3}
 
     with patch("promptlayer.tables.scorecards._get_requests_session") as mock_session:
-        mock_session.return_value.post.return_value = _mock_response(payload)
+        mock_session.return_value.post.return_value = _mock_response(payload, status_code=202)
 
         response = recalculate_scorecard(promptlayer_api_key, base_url, True, TABLE_ID, SHEET_ID, body)
 
@@ -119,8 +121,15 @@ def test_recalculate_scorecard_posts_options(promptlayer_api_key, base_url):
 
 
 def test_cancel_scorecard_posts_options(promptlayer_api_key, base_url):
-    body: CancelScorecardRequest = {"calculation_id": "calc_1"}
-    payload = {"success": True, "calculation_id": "calc_1", "status": "cancelled"}
+    body: CancelScorecardRequest = {"row_indices": [0, 1], "step_ids": ["step_1"]}
+    payload = {
+        "success": True,
+        "message": "Cancelled scorecard runs",
+        "scorecard": {"id": "sc_1"},
+        "cancelled_count": 1,
+        "execution_ids": ["exec_1"],
+        "calculation_id": "calc_1",
+    }
 
     with patch("promptlayer.tables.scorecards._get_requests_session") as mock_session:
         mock_session.return_value.post.return_value = _mock_response(payload)
@@ -144,8 +153,19 @@ def test_get_scorecard_calculation_sends_expected_request(promptlayer_api_key, b
 
 
 def test_list_scorecard_rows_forwards_query_params(promptlayer_api_key, base_url):
-    options: ListScorecardRowsOptions = {"calculation_id": "calc_1", "verdict": "fail", "limit": 25, "offset": 50}
-    payload = {"success": True, "rows": [{"row_index": 0, "verdict": "fail"}], "next_offset": None}
+    options: ListScorecardRowsOptions = {
+        "calculation_id": "calc_1",
+        "verdict": "fail",
+        "limit": 25,
+        "cursor": "cursor_1",
+    }
+    payload = {
+        "success": True,
+        "calculation_id": "calc_1",
+        "rows": [{"row_index": 0, "aggregate_verdict": "fail"}],
+        "next_cursor": None,
+        "verdict_counts": {"fail": 1},
+    }
 
     with patch("promptlayer.tables.scorecards._get_requests_session") as mock_session:
         mock_session.return_value.get.return_value = _mock_response(payload)
@@ -158,7 +178,17 @@ def test_list_scorecard_rows_forwards_query_params(promptlayer_api_key, base_url
 
 def test_get_scorecard_row_forwards_query_params(promptlayer_api_key, base_url):
     options: GetScorecardRowOptions = {"calculation_id": "calc_1"}
-    payload = {"success": True, "row": {"row_index": 0, "verdict": "fail", "criteria": []}}
+    payload = {
+        "success": True,
+        "row_index": 0,
+        "calculation_id": "calc_1",
+        "aggregate_score": 0.91,
+        "aggregate_verdict": "fail",
+        "step_results": {},
+        "drift_summary": None,
+        "stale_state": None,
+        "error_summary": None,
+    }
 
     with patch("promptlayer.tables.scorecards._get_requests_session") as mock_session:
         mock_session.return_value.get.return_value = _mock_response(payload)
@@ -210,6 +240,47 @@ async def test_async_get_scorecard_sends_expected_request(promptlayer_api_key, b
         assert response == payload
 
 
+@pytest.mark.asyncio
+async def test_async_configure_scorecard_patches_body(promptlayer_api_key, base_url):
+    body: ConfigureScorecardRequest = {
+        "name": "Quality Scorecard",
+        "evaluated_column_ids": [],
+        "aggregation": {"method": "weighted_mean"},
+        "steps": [],
+    }
+    payload = {"success": True, "scorecard": {"id": "sc_1", **body}}
+
+    with patch("promptlayer.tables.scorecards._make_httpx_client") as mock_client_factory:
+        mock_client = AsyncMock()
+        mock_client.patch.return_value = _mock_response(payload)
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mock_client_factory.return_value = mock_client
+
+        response = await aconfigure_scorecard(promptlayer_api_key, base_url, True, TABLE_ID, SHEET_ID, body)
+
+        _assert_request(mock_client.patch.call_args, base_url, promptlayer_api_key, json=body)
+        assert response == payload
+
+
+@pytest.mark.asyncio
+async def test_async_recalculate_scorecard_accepts_202_response(promptlayer_api_key, base_url):
+    body: RecalculateScorecardRequest = {"row_indices": [0], "step_ids": ["step_1"]}
+    payload = {"success": True, "calculation_id": "calc_1", "status": "queued", "version": 3}
+
+    with patch("promptlayer.tables.scorecards._make_httpx_client") as mock_client_factory:
+        mock_client = AsyncMock()
+        mock_client.post.return_value = _mock_response(payload, status_code=202)
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mock_client_factory.return_value = mock_client
+
+        response = await arecalculate_scorecard(promptlayer_api_key, base_url, True, TABLE_ID, SHEET_ID, body)
+
+        _assert_request(mock_client.post.call_args, base_url, promptlayer_api_key, "/recalculate", json=body)
+        assert response == payload
+
+
 def test_get_score_scorecard_compatibility_shape_is_supported_by_types():
     payload = cast(
         GetScoreScorecardCompatibilityResponse,
@@ -219,10 +290,15 @@ def test_get_score_scorecard_compatibility_shape_is_supported_by_types():
                 "score_type": "scorecard",
                 "scoring_type": "scorecard",
                 "score_configuration": None,
+                "overall_score": 0.91,
+                "aggregate_score": 0.91,
+                "status": "completed",
                 "details": {
                     "aggregate_result": {
                         "scorecard_id": "sc_1",
                         "scorecard_calculation_id": "calc_1",
+                        "aggregate_score": 0.91,
+                        "aggregate_verdict": "pass",
                     }
                 },
             },
@@ -231,6 +307,7 @@ def test_get_score_scorecard_compatibility_shape_is_supported_by_types():
 
     assert payload["score_configuration"] is None
     assert payload["details"]["aggregate_result"]["scorecard_calculation_id"] == "calc_1"
+    assert payload["aggregate_score"] == 0.91
 
 
 def test_recalculate_score_scorecard_piggyback_shape_is_supported_by_types():

--- a/tests/test_scorecards.py
+++ b/tests/test_scorecards.py
@@ -1,0 +1,252 @@
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from promptlayer.tables import (
+    aget_scorecard,
+    configure_scorecard,
+    delete_scorecard,
+    get_scorecard,
+    get_scorecard_calculation,
+    get_scorecard_row,
+    list_scorecard_rows,
+    migrate_legacy_score,
+    recalculate_scorecard,
+)
+from promptlayer.tables.scorecards import cancel_scorecard_calculation
+from promptlayer.types.scorecard import (
+    CancelScorecardRequest,
+    ConfigureScorecardRequest,
+    GetScoreScorecardCompatibilityResponse,
+    GetScorecardRowOptions,
+    ListScorecardRowsOptions,
+    MigrateLegacyScorecardRequest,
+    RecalculateScoreResponse,
+    RecalculateScorecardRequest,
+)
+
+TABLE_ID = "table/1"
+SHEET_ID = "sheet 2"
+ENCODED_BASE = "/api/public/v2/tables/table%2F1/sheets/sheet%202/scorecard"
+
+
+def _mock_response(payload, status_code=200):
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = payload
+    return response
+
+
+def _assert_request(call_args, base_url, api_key, suffix="", *, json=None, params=None):
+    assert call_args[0][0] == f"{base_url}{ENCODED_BASE}{suffix}"
+    assert call_args[1]["headers"] == {"X-API-KEY": api_key}
+    assert call_args[1]["json"] == json
+    assert call_args[1]["params"] == params
+
+
+def test_get_scorecard_sends_expected_request(promptlayer_api_key, base_url):
+    payload = {"success": True, "scorecard": {"id": "sc_1", "name": "Quality"}}
+
+    with patch("promptlayer.tables.scorecards._get_requests_session") as mock_session:
+        mock_session.return_value.get.return_value = _mock_response(payload)
+
+        response = get_scorecard(promptlayer_api_key, base_url, True, TABLE_ID, SHEET_ID)
+
+        _assert_request(mock_session.return_value.get.call_args, base_url, promptlayer_api_key)
+        assert response == payload
+
+
+def test_configure_scorecard_puts_body(promptlayer_api_key, base_url):
+    body: ConfigureScorecardRequest = {
+        "name": "Quality Scorecard",
+        "evaluated_column_ids": [],
+        "aggregation": {
+            "method": "weighted_mean",
+            "required_step_failure_behavior": "fail",
+            "pass_threshold": 0.8,
+            "warn_threshold": 0.6,
+        },
+        "steps": [],
+    }
+    payload = {"success": True, "scorecard": {"id": "sc_1", **body}}
+
+    with patch("promptlayer.tables.scorecards._get_requests_session") as mock_session:
+        mock_session.return_value.put.return_value = _mock_response(payload)
+
+        response = configure_scorecard(promptlayer_api_key, base_url, True, TABLE_ID, SHEET_ID, body)
+
+        _assert_request(mock_session.return_value.put.call_args, base_url, promptlayer_api_key, json=body)
+        assert response == payload
+
+
+def test_migrate_legacy_score_posts_options(promptlayer_api_key, base_url):
+    body: MigrateLegacyScorecardRequest = {"delete_legacy_score": False}
+    payload = {"success": True, "scorecard": {"id": "sc_1"}}
+
+    with patch("promptlayer.tables.scorecards._get_requests_session") as mock_session:
+        mock_session.return_value.post.return_value = _mock_response(payload)
+
+        response = migrate_legacy_score(promptlayer_api_key, base_url, True, TABLE_ID, SHEET_ID, body)
+
+        _assert_request(
+            mock_session.return_value.post.call_args,
+            base_url,
+            promptlayer_api_key,
+            "/migrate-legacy-score",
+            json=body,
+        )
+        assert response == payload
+
+
+def test_recalculate_scorecard_posts_options(promptlayer_api_key, base_url):
+    body: RecalculateScorecardRequest = {"row_indices": [0, 1], "force": True}
+    payload = {"success": True, "calculation_id": "calc_1", "status": "queued", "version": 3}
+
+    with patch("promptlayer.tables.scorecards._get_requests_session") as mock_session:
+        mock_session.return_value.post.return_value = _mock_response(payload)
+
+        response = recalculate_scorecard(promptlayer_api_key, base_url, True, TABLE_ID, SHEET_ID, body)
+
+        _assert_request(
+            mock_session.return_value.post.call_args,
+            base_url,
+            promptlayer_api_key,
+            "/recalculate",
+            json=body,
+        )
+        assert response == payload
+
+
+def test_cancel_scorecard_posts_options(promptlayer_api_key, base_url):
+    body: CancelScorecardRequest = {"calculation_id": "calc_1"}
+    payload = {"success": True, "calculation_id": "calc_1", "status": "cancelled"}
+
+    with patch("promptlayer.tables.scorecards._get_requests_session") as mock_session:
+        mock_session.return_value.post.return_value = _mock_response(payload)
+
+        response = cancel_scorecard_calculation(promptlayer_api_key, base_url, True, TABLE_ID, SHEET_ID, body)
+
+        _assert_request(mock_session.return_value.post.call_args, base_url, promptlayer_api_key, "/cancel", json=body)
+        assert response == payload
+
+
+def test_get_scorecard_calculation_sends_expected_request(promptlayer_api_key, base_url):
+    payload = {"success": True, "calculation": {"id": "calc_1", "status": "completed"}}
+
+    with patch("promptlayer.tables.scorecards._get_requests_session") as mock_session:
+        mock_session.return_value.get.return_value = _mock_response(payload)
+
+        response = get_scorecard_calculation(promptlayer_api_key, base_url, True, TABLE_ID, SHEET_ID, "calc_1")
+
+        _assert_request(mock_session.return_value.get.call_args, base_url, promptlayer_api_key, "/calculations/calc_1")
+        assert response == payload
+
+
+def test_list_scorecard_rows_forwards_query_params(promptlayer_api_key, base_url):
+    options: ListScorecardRowsOptions = {"calculation_id": "calc_1", "verdict": "fail", "limit": 25, "offset": 50}
+    payload = {"success": True, "rows": [{"row_index": 0, "verdict": "fail"}], "next_offset": None}
+
+    with patch("promptlayer.tables.scorecards._get_requests_session") as mock_session:
+        mock_session.return_value.get.return_value = _mock_response(payload)
+
+        response = list_scorecard_rows(promptlayer_api_key, base_url, True, TABLE_ID, SHEET_ID, options)
+
+        _assert_request(mock_session.return_value.get.call_args, base_url, promptlayer_api_key, "/rows", params=options)
+        assert response == payload
+
+
+def test_get_scorecard_row_forwards_query_params(promptlayer_api_key, base_url):
+    options: GetScorecardRowOptions = {"calculation_id": "calc_1"}
+    payload = {"success": True, "row": {"row_index": 0, "verdict": "fail", "criteria": []}}
+
+    with patch("promptlayer.tables.scorecards._get_requests_session") as mock_session:
+        mock_session.return_value.get.return_value = _mock_response(payload)
+
+        response = get_scorecard_row(promptlayer_api_key, base_url, True, TABLE_ID, SHEET_ID, 0, options)
+
+        _assert_request(
+            mock_session.return_value.get.call_args,
+            base_url,
+            promptlayer_api_key,
+            "/rows/0",
+            params=options,
+        )
+        assert response == payload
+
+
+def test_delete_scorecard_sends_expected_request(promptlayer_api_key, base_url):
+    payload = {"success": True}
+
+    with patch("promptlayer.tables.scorecards._get_requests_session") as mock_session:
+        mock_session.return_value.delete.return_value = _mock_response(payload)
+
+        response = delete_scorecard(promptlayer_api_key, base_url, True, TABLE_ID, SHEET_ID)
+
+        _assert_request(mock_session.return_value.delete.call_args, base_url, promptlayer_api_key)
+        assert response == payload
+
+
+def test_scorecard_manager_is_available_on_client(promptlayer_client):
+    assert hasattr(promptlayer_client.tables.sheets.scorecards, "get")
+    assert hasattr(promptlayer_client.tables.sheets.scorecards, "configure")
+    assert hasattr(promptlayer_client.tables.sheets.scorecards, "migrate_legacy_score")
+
+
+@pytest.mark.asyncio
+async def test_async_get_scorecard_sends_expected_request(promptlayer_api_key, base_url):
+    payload = {"success": True, "scorecard": {"id": "sc_1", "name": "Quality"}}
+
+    with patch("promptlayer.tables.scorecards._make_httpx_client") as mock_client_factory:
+        mock_client = AsyncMock()
+        mock_client.get.return_value = _mock_response(payload)
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mock_client_factory.return_value = mock_client
+
+        response = await aget_scorecard(promptlayer_api_key, base_url, True, TABLE_ID, SHEET_ID)
+
+        _assert_request(mock_client.get.call_args, base_url, promptlayer_api_key)
+        assert response == payload
+
+
+def test_get_score_scorecard_compatibility_shape_is_supported_by_types():
+    payload = cast(
+        GetScoreScorecardCompatibilityResponse,
+        cast(
+            object,
+            {
+                "score_type": "scorecard",
+                "scoring_type": "scorecard",
+                "score_configuration": None,
+                "details": {
+                    "aggregate_result": {
+                        "scorecard_id": "sc_1",
+                        "scorecard_calculation_id": "calc_1",
+                    }
+                },
+            },
+        ),
+    )
+
+    assert payload["score_configuration"] is None
+    assert payload["details"]["aggregate_result"]["scorecard_calculation_id"] == "calc_1"
+
+
+def test_recalculate_score_scorecard_piggyback_shape_is_supported_by_types():
+    payload = cast(
+        RecalculateScoreResponse,
+        cast(
+            object,
+            {
+                "success": True,
+                "score_source": "scorecard",
+                "calculation_id": "calc_1",
+                "status": "queued",
+                "version": 2,
+            },
+        ),
+    )
+
+    assert payload["success"] is True
+    assert payload["status"] == "queued"

--- a/tests/test_scorecards.py
+++ b/tests/test_scorecards.py
@@ -18,12 +18,12 @@ from promptlayer.tables.scorecards import cancel_scorecard_calculation
 from promptlayer.types.scorecard import (
     CancelScorecardRequest,
     ConfigureScorecardRequest,
-    GetScoreScorecardCompatibilityResponse,
     GetScorecardRowOptions,
+    GetScoreScorecardCompatibilityResponse,
     ListScorecardRowsOptions,
     MigrateLegacyScorecardRequest,
-    RecalculateScoreResponse,
     RecalculateScorecardRequest,
+    RecalculateScoreResponse,
 )
 
 TABLE_ID = "table/1"


### PR DESCRIPTION
## Summary
- add table scorecard clients under `client.tables.sheets.scorecards` for sync and async SDK usage
- add scorecard request/response TypedDicts, including compatibility types for scorecard-shaped legacy `/score` responses
- add mock HTTP tests for scorecard endpoint paths, methods, params, and bodies
- document table scorecard usage, migration caveats, and release notes

## Validation
- `poetry run python -m compileall promptlayer tests/test_scorecards.py`

Could not run pytest/ruff locally because the fresh Poetry environment is missing dev/runtime dependencies (`pytest`, `ruff`, `nest_asyncio`).