### PR TITLE
Fixed google thought signature

### DIFF
--- a/promptlayer/__init__.py
+++ b/promptlayer/__init__.py
@@ -16,7 +16,7 @@ from .exceptions import (
 )
 from .promptlayer import AsyncPromptLayer, PromptLayer
 
-__version__ = "1.4.6"
+__version__ = "1.4.7"
 __all__ = [
     "PromptLayer",
     "AsyncPromptLayer",

--- a/promptlayer/streaming/blueprint_builder.py
+++ b/promptlayer/streaming/blueprint_builder.py
@@ -16,11 +16,19 @@ _OUTPUT_FORMAT_TO_MIME = {
 }
 
 
-def _create_tool_call(call_id: str, function_name: str, arguments: Any, tool_id: str = None) -> Dict[str, Any]:
+def _create_tool_call(
+    call_id: str,
+    function_name: str,
+    arguments: Any,
+    tool_id: str = None,
+    provider_metadata: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """Create a standardized tool call structure"""
     tool_call = {"id": call_id, "type": "function", "function": {"name": function_name, "arguments": arguments}}
     if tool_id:
         tool_call["tool_id"] = tool_id
+    if provider_metadata:
+        tool_call["provider_metadata"] = provider_metadata
     return tool_call
 
 
@@ -978,15 +986,23 @@ def build_prompt_blueprint_from_google_event(event, metadata):
                     content_kwargs["provider_metadata"] = {"thought_signature": thought_sig}
                 assistant_content.append(_create_content_item("output_media", **content_kwargs))
             elif hasattr(part, "thought") and part.thought is True and hasattr(part, "text") and part.text:
-                assistant_content.append(_create_content_item("thinking", thinking=part.text, signature=None))
+                assistant_content.append(
+                    _create_content_item(
+                        "thinking",
+                        thinking=part.text,
+                        signature=getattr(part, "thought_signature", None),
+                    )
+                )
             elif hasattr(part, "text") and part.text is not None:
                 assistant_content.append(_create_content_item("text", text=part.text))
             elif hasattr(part, "function_call") and part.function_call:
+                thought_signature = getattr(part, "thought_signature", None)
                 tool_calls.append(
                     _create_tool_call(
                         getattr(part.function_call, "id", ""),
                         getattr(part.function_call, "name", ""),
                         getattr(part.function_call, "args", {}),
+                        provider_metadata={"thought_signature": thought_signature} if thought_signature else None,
                     )
                 )
 

--- a/promptlayer/streaming/response_handlers.py
+++ b/promptlayer/streaming/response_handlers.py
@@ -930,8 +930,12 @@ def _build_google_response_from_parts(
         text_part = Part(text=regular_content, thought=None)
         final_parts.append(text_part)
 
-    for function_call in function_calls:
-        function_part = Part(function_call=function_call, thought=None)
+    for function_call, thought_signature in function_calls:
+        function_part = Part(
+            function_call=function_call,
+            thought=None,
+            thought_signature=thought_signature,
+        )
         final_parts.append(function_part)
 
     final_parts.extend(extra_parts)
@@ -968,7 +972,7 @@ async def amap_google_stream_response(generator: AsyncIterable[Any]):
                 elif hasattr(part, "text") and part.text:
                     regular_content = f"{regular_content}{part.text}"
                 elif hasattr(part, "function_call") and part.function_call:
-                    function_calls.append(part.function_call)
+                    function_calls.append((part.function_call, getattr(part, "thought_signature", None)))
 
     if not last_result:
         return response
@@ -1011,7 +1015,7 @@ def map_google_stream_response(results: list):
                 elif hasattr(part, "text") and part.text:
                     regular_content = f"{regular_content}{part.text}"
                 elif hasattr(part, "function_call") and part.function_call:
-                    function_calls.append(part.function_call)
+                    function_calls.append((part.function_call, getattr(part, "thought_signature", None)))
 
     return _build_google_response_from_parts(thought_content, regular_content, function_calls, extra_parts, results[-1])
 

--- a/promptlayer/types/prompt_template.py
+++ b/promptlayer/types/prompt_template.py
@@ -287,6 +287,7 @@ class ToolCall(TypedDict, total=False):
     tool_id: Union[str, None]
     type: Literal["function"]
     function: FunctionCall
+    provider_metadata: Union[Dict[str, Any], None]
 
 
 class AssistantMessage(TypedDict, total=False):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "promptlayer"
-version = "1.4.6"
+version = "1.4.7"
 description = "PromptLayer is a platform for prompt engineering and tracks your LLM requests."
 authors = ["Magniv <hello@magniv.io>"]
 license = "Apache-2.0"

--- a/tests/test_builtin_tools_streaming.py
+++ b/tests/test_builtin_tools_streaming.py
@@ -10,6 +10,7 @@ from promptlayer.streaming.blueprint_builder import (
     build_prompt_blueprint_from_openai_responses_event,
 )
 from promptlayer.streaming.response_handlers import (
+    _build_google_response_from_parts,
     _process_openai_response_event,
     openai_images_stream,
 )
@@ -619,6 +620,24 @@ def _make_google_event(parts, grounding_metadata=None, url_context_metadata=None
 class TestGoogleBlueprintBuilder:
     """Test Google blueprint builder with new part types."""
 
+    def test_stream_response_preserves_function_call_thought_signature(self):
+        from google.genai import types
+
+        response = SimpleNamespace(candidates=[SimpleNamespace(content=SimpleNamespace(parts=[]))])
+        last_result = MagicMock()
+        last_result.model_copy.return_value = response
+        function_call = types.FunctionCall(name="get_knowledge", args={"customerQuery": "store information"})
+
+        result = _build_google_response_from_parts(
+            "",
+            "",
+            [(function_call, b"thought-signature")],
+            [],
+            last_result,
+        )
+
+        assert result.candidates[0].content.parts[0].thought_signature == b"thought-signature"
+
     def test_executable_code_part(self):
         exec_code = SimpleNamespace(code="print('hello')", language="PYTHON")
         part = SimpleNamespace(
@@ -723,6 +742,28 @@ class TestGoogleBlueprintBuilder:
         msg = bp["prompt_template"]["messages"][0]
         assert msg["content"][0]["type"] == "thinking"
         assert msg["content"][0]["thinking"] == "thinking..."
+
+    def test_function_call_preserves_thought_signature(self):
+        function_call = SimpleNamespace(
+            id="call_get_knowledge",
+            name="get_knowledge",
+            args={"customerQuery": "store information"},
+        )
+        part = SimpleNamespace(
+            thought=False,
+            thought_signature="U0lHX1RPT0xfQ0FMTA==",
+            executable_code=None,
+            code_execution_result=None,
+            inline_data=None,
+            text=None,
+            function_call=function_call,
+        )
+
+        event = _make_google_event([part])
+        bp = build_prompt_blueprint_from_google_event(event, METADATA)
+        tool_call = bp["prompt_template"]["messages"][0]["tool_calls"][0]
+
+        assert tool_call["provider_metadata"] == {"thought_signature": "U0lHX1RPT0xfQ0FMTA=="}
 
     def test_web_search_grounding_annotations(self):
         """Grounding metadata with web chunks produces url_citation annotations on text."""


### PR DESCRIPTION
### Summary

Gemini attaches a `thought_signature` to function-call parts when a "thinking" model produces a tool call. This signature must be echoed back on subsequent turns so the model can continue its chain of thought — dropping it can cause degraded output or 400s on follow-up requests.

Previously, when we normalized Google responses into our prompt-blueprint / streaming payloads, the `thought_signature` on function-call parts was being discarded. This PR keeps it end-to-end.

### Changes

- `ToolCall` schema: added an optional `provider_metadata` field to carry provider-specific data through the blueprint.
- Google blueprint builder: when a `functionCall` part has a `thought_signature`, it is now attached as `provider_metadata.thought_signature` on the resulting `ToolCall`.
- Google streaming path: function-call parts now carry their `thought_signature` alongside the `functionCall` payload (previously the sibling `thought_signature` was dropped during part reconstruction).
- Added unit tests covering both the blueprint builder and the streaming reconstruction to lock in the behavior.

### Why it matters

Gemini's docs require the `thought_signature` to be returned as-is on the next turn when function calling with a thinking model. Without this fix, multi-turn tool-calling flows through PromptLayer would silently strip the signature, breaking Google's reasoning continuity.

### Testing

- `pytest` — all existing + new tests pass.
- Verified via unit tests that a function-call part with `thought_signature="sig-tool-call"` produces a `ToolCall` with `provider_metadata={"thought_signature": "sig-tool-call"}`.
