### PR TITLE
Unify eval scorer parameter names

### DIFF
--- a/promptlayer/__init__.py
+++ b/promptlayer/__init__.py
@@ -36,7 +36,7 @@ from .exceptions import (
 from .promptlayer import AsyncPromptLayer, PromptLayer
 from .tracing import NATIVE_OTEL_PROVIDERS, configure_tracing, instrument_openai
 
-__version__ = "1.5.3"
+__version__ = "1.5.4"
 __all__ = [
     "PromptLayer",
     "AsyncPromptLayer",

--- a/promptlayer/evaluations/scorers/_helpers.py
+++ b/promptlayer/evaluations/scorers/_helpers.py
@@ -28,6 +28,13 @@ def require_non_empty_source(source: str, scorer_name: str, *, field: str = "sou
         raise validation_error(f"{scorer_name} {field} must be a non-empty string.")
 
 
+def reject_legacy_parameters(settings: Dict[str, Any], *, names: Sequence[str], scorer_name: str) -> None:
+    legacy_names = [name for name in names if name in settings]
+    if legacy_names:
+        rendered = ", ".join(legacy_names)
+        raise validation_error(f"{scorer_name} no longer accepts legacy parameter(s): {rendered}.")
+
+
 def require_exactly_one_of(
     *present: bool,
     names: Sequence[str],
@@ -49,10 +56,10 @@ def require_one_of_modes(value: str, allowed: Iterable[str], scorer_name: str, *
 
 def require_non_empty_tools(expected_tools: List[str]) -> None:
     if not isinstance(expected_tools, list) or not expected_tools:
-        raise validation_error("trajectory_scorer requires a non-empty expected_tools list.")
+        raise validation_error("trajectory_scorer expected must contain non-empty scenario lists.")
     for tool in expected_tools:
         if not isinstance(tool, str) or not tool.strip():
-            raise validation_error("trajectory_scorer expected_tools must be non-empty strings.")
+            raise validation_error("trajectory_scorer expected tool names must be non-empty strings.")
 
 
 def require_count_bounds(

--- a/promptlayer/evaluations/scorers/assert_valid.py
+++ b/promptlayer/evaluations/scorers/assert_valid.py
@@ -8,6 +8,7 @@ from promptlayer.evaluations.columns import column
 from promptlayer.evaluations.scorers._helpers import (
     apply_scorecard_step_options,
     pop_scorecard_step_options,
+    reject_legacy_parameters,
     require_non_empty_source,
     require_non_empty_string,
     require_non_empty_title,
@@ -18,14 +19,15 @@ from promptlayer.types.table import EvalScorerColumn
 def assert_valid_scorer(
     title: str = "Assert valid",
     *,
-    source: str = "Output",
+    source_column: str = "Output",
     type: str = "object",
     **settings: Any,
 ) -> EvalScorerColumn:
     """Build an ASSERT_VALID scorer column."""
+    reject_legacy_parameters(settings, names=("source",), scorer_name="assert_valid_scorer")
     require_non_empty_title(title, "assert_valid_scorer")
-    require_non_empty_source(source, "assert_valid_scorer")
+    require_non_empty_source(source_column, "assert_valid_scorer", field="source_column")
     require_non_empty_string(type, field="type", scorer_name="assert_valid_scorer")
     step_options, config_settings = pop_scorecard_step_options(settings)
-    config: Dict[str, Any] = {"source": source, "type": type, **config_settings}
+    config: Dict[str, Any] = {"source": source_column, "type": type, **config_settings}
     return apply_scorecard_step_options(column(title, "ASSERT_VALID", config), **step_options)

--- a/promptlayer/evaluations/scorers/compare.py
+++ b/promptlayer/evaluations/scorers/compare.py
@@ -8,25 +8,39 @@ from promptlayer.evaluations.columns import column
 from promptlayer.evaluations.scorers._helpers import (
     apply_scorecard_step_options,
     pop_scorecard_step_options,
+    reject_legacy_parameters,
+    require_non_empty_source,
     require_non_empty_title,
 )
 from promptlayer.evaluations.validation import validation_error
 from promptlayer.types.table import EvalScorerColumn
 
+_UNSET = object()
+
 
 def compare_scorer(
     title: str = "Compare",
     *,
-    source: str = "Output",
-    value_source: str = "expected",
+    source_column: str = "Output",
+    expected: Any = _UNSET,
+    expected_column: Optional[str] = None,
     comparison_type: Optional[Union[Dict[str, Any], str]] = None,
     **settings: Any,
 ) -> EvalScorerColumn:
     """Build a COMPARE scorer column."""
+    reject_legacy_parameters(
+        settings,
+        names=("source", "value_source"),
+        scorer_name="compare_scorer",
+    )
     require_non_empty_title(title, "compare_scorer")
-    for field, value in (("source", source), ("value_source", value_source)):
-        if not isinstance(value, str) or not value.strip():
-            raise validation_error(f"compare_scorer {field} must be a non-empty string.")
+    require_non_empty_source(source_column, "compare_scorer", field="source_column")
+    if expected is not _UNSET and expected_column is not None:
+        raise validation_error("compare_scorer accepts only one of expected or expected_column.")
+    if expected is _UNSET and expected_column is None:
+        expected_column = "expected"
+    if expected_column is not None:
+        require_non_empty_source(expected_column, "compare_scorer", field="expected_column")
     if comparison_type is None:
         comparison: Union[Dict[str, Any], str] = {"type": "STRING"}
     elif isinstance(comparison_type, str):
@@ -35,8 +49,12 @@ def compare_scorer(
         comparison = comparison_type
     step_options, config_settings = pop_scorecard_step_options(settings)
     config: Dict[str, Any] = {
-        "sources": [source, value_source],
+        "sources": [source_column],
         "comparison_type": comparison,
         **config_settings,
     }
+    if expected is not _UNSET:
+        config["target"] = expected
+    else:
+        config["sources"].append(expected_column)
     return apply_scorecard_step_options(column(title, "COMPARE", config), **step_options)

--- a/promptlayer/evaluations/scorers/contains.py
+++ b/promptlayer/evaluations/scorers/contains.py
@@ -8,30 +8,41 @@ from promptlayer.evaluations.columns import column
 from promptlayer.evaluations.scorers._helpers import (
     apply_scorecard_step_options,
     pop_scorecard_step_options,
+    reject_legacy_parameters,
+    require_exactly_one_of,
     require_non_empty_source,
     require_non_empty_title,
 )
-from promptlayer.evaluations.validation import validation_error
 from promptlayer.types.table import EvalScorerColumn
 
 
 def contains_scorer(
     title: str = "Contains",
     *,
-    source: str = "Output",
-    value: Optional[str] = None,
-    value_source: Optional[str] = None,
+    source_column: str = "Output",
+    expected: Optional[str] = None,
+    expected_column: Optional[str] = None,
     **settings: Any,
 ) -> EvalScorerColumn:
     """Build a CONTAINS scorer column."""
+    reject_legacy_parameters(
+        settings,
+        names=("source", "value", "value_source"),
+        scorer_name="contains_scorer",
+    )
     require_non_empty_title(title, "contains_scorer")
-    require_non_empty_source(source, "contains_scorer")
-    if value is None and value_source is None:
-        raise validation_error("contains_scorer requires either value or value_source.")
+    require_non_empty_source(source_column, "contains_scorer", field="source_column")
+    require_exactly_one_of(
+        expected is not None,
+        expected_column is not None,
+        names=("expected", "expected_column"),
+        scorer_name="contains_scorer",
+    )
     step_options, config_settings = pop_scorecard_step_options(settings)
-    config: Dict[str, Any] = {"source": source, **config_settings}
-    if value is not None:
-        config["value"] = value
-    if value_source is not None:
-        config["value_source"] = value_source
+    config: Dict[str, Any] = {"source": source_column, **config_settings}
+    if expected is not None:
+        config["value"] = expected
+    if expected_column is not None:
+        require_non_empty_source(expected_column, "contains_scorer", field="expected_column")
+        config["value_source"] = expected_column
     return apply_scorecard_step_options(column(title, "CONTAINS", config), **step_options)

--- a/promptlayer/evaluations/scorers/count.py
+++ b/promptlayer/evaluations/scorers/count.py
@@ -8,6 +8,7 @@ from promptlayer.evaluations.columns import column
 from promptlayer.evaluations.scorers._helpers import (
     apply_scorecard_step_options,
     pop_scorecard_step_options,
+    reject_legacy_parameters,
     require_count_bounds,
     require_non_empty_source,
     require_non_empty_string,
@@ -19,19 +20,20 @@ from promptlayer.types.table import EvalScorerColumn
 def count_scorer(
     title: str = "Count",
     *,
-    source: str = "Output",
+    source_column: str = "Output",
     type: str = "chars",
     min_count: Optional[int] = None,
     max_count: Optional[int] = None,
     **settings: Any,
 ) -> EvalScorerColumn:
     """Build a COUNT scorer column."""
+    reject_legacy_parameters(settings, names=("source",), scorer_name="count_scorer")
     require_non_empty_title(title, "count_scorer")
-    require_non_empty_source(source, "count_scorer")
+    require_non_empty_source(source_column, "count_scorer", field="source_column")
     require_non_empty_string(type, field="type", scorer_name="count_scorer")
     require_count_bounds(min_count=min_count, max_count=max_count)
     step_options, config_settings = pop_scorecard_step_options(settings)
-    config: Dict[str, Any] = {"source": source, "type": type, **config_settings}
+    config: Dict[str, Any] = {"source": source_column, "type": type, **config_settings}
     if min_count is not None:
         config["min_count"] = min_count
     if max_count is not None:

--- a/promptlayer/evaluations/scorers/llm_assertion.py
+++ b/promptlayer/evaluations/scorers/llm_assertion.py
@@ -8,6 +8,7 @@ from promptlayer.evaluations.columns import column
 from promptlayer.evaluations.scorers._helpers import (
     apply_scorecard_step_options,
     pop_scorecard_step_options,
+    reject_legacy_parameters,
     require_non_empty_source,
     require_non_empty_title,
 )
@@ -18,19 +19,20 @@ from promptlayer.types.table import EvalScorerColumn
 def llm_assertion_scorer(
     title: str = "LLM assertion",
     *,
-    source: str = "Output",
+    source_column: str = "Output",
     prompt: Optional[str] = None,
     prompt_source: Optional[str] = None,
     variable_mappings: Optional[Dict[str, str]] = None,
     **settings: Any,
 ) -> EvalScorerColumn:
     """Build an LLM_ASSERTION scorer column."""
+    reject_legacy_parameters(settings, names=("source",), scorer_name="llm_assertion_scorer")
     require_non_empty_title(title, "llm_assertion_scorer")
-    require_non_empty_source(source, "llm_assertion_scorer")
+    require_non_empty_source(source_column, "llm_assertion_scorer", field="source_column")
     if prompt is None and prompt_source is None:
         raise validation_error("llm_assertion_scorer requires either prompt or prompt_source.")
     step_options, config_settings = pop_scorecard_step_options(settings)
-    config: Dict[str, Any] = {"source": source, **config_settings}
+    config: Dict[str, Any] = {"source": source_column, **config_settings}
     if prompt is not None:
         config["prompt"] = prompt
     if prompt_source is not None:

--- a/promptlayer/evaluations/scorers/regex.py
+++ b/promptlayer/evaluations/scorers/regex.py
@@ -8,6 +8,7 @@ from promptlayer.evaluations.columns import column
 from promptlayer.evaluations.scorers._helpers import (
     apply_scorecard_step_options,
     pop_scorecard_step_options,
+    reject_legacy_parameters,
     require_non_empty_source,
     require_non_empty_string,
     require_non_empty_title,
@@ -18,17 +19,18 @@ from promptlayer.types.table import EvalScorerColumn
 def regex_scorer(
     title: str = "Regex",
     *,
-    source: str = "Output",
+    source_column: str = "Output",
     regex_pattern: str,
     **settings: Any,
 ) -> EvalScorerColumn:
     """Build a REGEX scorer column."""
+    reject_legacy_parameters(settings, names=("source",), scorer_name="regex_scorer")
     require_non_empty_title(title, "regex_scorer")
-    require_non_empty_source(source, "regex_scorer")
+    require_non_empty_source(source_column, "regex_scorer", field="source_column")
     require_non_empty_string(regex_pattern, field="regex_pattern", scorer_name="regex_scorer")
     step_options, config_settings = pop_scorecard_step_options(settings)
     config: Dict[str, Any] = {
-        "source": source,
+        "source": source_column,
         "regex_pattern": regex_pattern,
         **config_settings,
     }

--- a/promptlayer/evaluations/scorers/trajectory.py
+++ b/promptlayer/evaluations/scorers/trajectory.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Literal, Optional, Union
 from promptlayer.evaluations.columns import column
 from promptlayer.evaluations.scorers._helpers import (
     apply_scorecard_step_options,
+    reject_legacy_parameters,
     require_exactly_one_of,
     require_non_empty_source,
     require_non_empty_title,
@@ -153,9 +154,9 @@ def diagnose_trajectory_failure(
 
 def trajectory_scorer(
     *,
-    accepted_scenarios: Optional[List[List[str]]] = None,
-    value_source: Optional[str] = None,
-    source: str = "Trace",
+    expected: Optional[List[List[str]]] = None,
+    expected_column: Optional[str] = None,
+    source_column: str = "Trace",
     mode: TrajectoryMode = "strict",
     title: str = "Trajectory",
     weight: Optional[float] = None,
@@ -166,28 +167,33 @@ def trajectory_scorer(
     **settings: Any,
 ) -> EvalScorerColumn:
     """Build a TRAJECTORY scorer column."""
+    reject_legacy_parameters(
+        settings,
+        names=("accepted_scenarios", "value_source", "source"),
+        scorer_name="trajectory_scorer",
+    )
     require_non_empty_title(title, "trajectory_scorer")
     require_exactly_one_of(
-        accepted_scenarios is not None,
-        value_source is not None,
-        names=("accepted_scenarios", "value_source"),
+        expected is not None,
+        expected_column is not None,
+        names=("expected", "expected_column"),
         scorer_name="trajectory_scorer",
     )
     require_one_of_modes(mode, ("strict", "non_strict"), "trajectory_scorer")
-    require_non_empty_source(source, "trajectory_scorer")
+    require_non_empty_source(source_column, "trajectory_scorer", field="source_column")
 
-    config: Dict[str, Any] = {"trace_source": source, **settings, "mode": mode}
-    if accepted_scenarios is not None:
-        if not isinstance(accepted_scenarios, list) or not accepted_scenarios:
-            raise validation_error("trajectory_scorer accepted_scenarios must be a non-empty list.")
+    config: Dict[str, Any] = {"trace_source": source_column, **settings, "mode": mode}
+    if expected is not None:
+        if not isinstance(expected, list) or not expected:
+            raise validation_error("trajectory_scorer expected must be a non-empty list.")
         normalized: List[List[str]] = []
-        for scenario in accepted_scenarios:
+        for scenario in expected:
             require_non_empty_tools(scenario)
             normalized.append(list(scenario))
         config["accepted_scenarios"] = normalized
     else:
-        require_non_empty_source(value_source, "trajectory_scorer", field="value_source")
-        config["expected_source"] = value_source
+        require_non_empty_source(expected_column, "trajectory_scorer", field="expected_column")
+        config["expected_source"] = expected_column
 
     payload = column(
         title,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "promptlayer"
-version = "1.5.3"
+version = "1.5.4"
 description = "PromptLayer is a platform for prompt engineering and tracks your LLM requests."
 authors = ["Magniv <hello@magniv.io>"]
 license = "Apache-2.0"

--- a/tests/test_eval_scorers.py
+++ b/tests/test_eval_scorers.py
@@ -75,14 +75,25 @@ def test_predefined_scorer_payloads():
             "comparison_type": {"type": "STRING"},
         },
     }
-    custom_compare = compare_scorer(source="actual", value_source="reference")
+    custom_compare = compare_scorer(source_column="actual", expected_column="reference")
     assert custom_compare["config"]["sources"] == ["actual", "reference"]
+    literal_compare = compare_scorer(expected=None, comparison_type="JSON")
+    assert literal_compare["config"] == {
+        "sources": ["Output"],
+        "target": None,
+        "comparison_type": {"type": "JSON"},
+    }
 
-    contains = contains_scorer(value="refund")
+    contains = contains_scorer(expected="refund")
     assert contains == {
         "title": "Contains",
         "type": "CONTAINS",
         "config": {"source": "Output", "value": "refund"},
+    }
+    contains_column = contains_scorer(expected_column="reference")
+    assert contains_column["config"] == {
+        "source": "Output",
+        "value_source": "reference",
     }
 
     regex = regex_scorer(regex_pattern=r"inv_\d+")
@@ -118,7 +129,7 @@ def test_predefined_scorer_payloads():
         "config": {"source": "Output", "type": "object"},
     }
 
-    assert_valid_custom = assert_valid_scorer(type="email", source="contact")
+    assert_valid_custom = assert_valid_scorer(type="email", source_column="contact")
     assert assert_valid_custom == {
         "title": "Assert valid",
         "type": "ASSERT_VALID",
@@ -126,7 +137,7 @@ def test_predefined_scorer_payloads():
     }
 
     trajectory = trajectory_scorer(
-        accepted_scenarios=[["search", "checkout"]],
+        expected=[["search", "checkout"]],
         mode="strict",
     )
     assert trajectory == {
@@ -139,7 +150,7 @@ def test_predefined_scorer_payloads():
         },
     }
 
-    advanced_trajectory = trajectory_scorer(value_source="expected", title="trajectory assertions v3")
+    advanced_trajectory = trajectory_scorer(expected_column="expected", title="trajectory assertions v3")
     assert advanced_trajectory == {
         "title": "trajectory assertions v3",
         "type": "TRAJECTORY",
@@ -148,7 +159,7 @@ def test_predefined_scorer_payloads():
 
     expected_trace_trajectory = trajectory_scorer(
         title="expected trace trajectory",
-        value_source="expected_trace",
+        expected_column="expected_trace",
         mode="non_strict",
     )
     assert expected_trace_trajectory["config"] == {
@@ -157,31 +168,33 @@ def test_predefined_scorer_payloads():
         "mode": "non_strict",
     }
     custom_source_trajectory = trajectory_scorer(
-        source="Agent trace",
-        accepted_scenarios=[["search"]],
+        source_column="Agent trace",
+        expected=[["search"]],
     )
     assert custom_source_trajectory["config"]["trace_source"] == "Agent trace"
-    custom_value_source_trajectory = trajectory_scorer(value_source="expected trajectory")
+    custom_value_source_trajectory = trajectory_scorer(expected_column="expected trajectory")
     assert custom_value_source_trajectory["config"]["expected_source"] == "expected trajectory"
 
 
 def test_predefined_scorer_validation():
     with pytest.raises(PromptLayerValidationError):
-        trajectory_scorer(accepted_scenarios=[])
+        trajectory_scorer(expected=[])
     with pytest.raises(PromptLayerValidationError):
         trajectory_scorer()
     with pytest.raises(PromptLayerValidationError):
         trajectory_scorer(
-            accepted_scenarios=[["search"]],
-            value_source="expected",
+            expected=[["search"]],
+            expected_column="expected",
         )
     with pytest.raises(PromptLayerValidationError):
         trajectory_scorer(
-            accepted_scenarios=[["search"]],
+            expected=[["search"]],
             mode="invalid",  # type: ignore[arg-type]
         )
     with pytest.raises(PromptLayerValidationError):
         contains_scorer()
+    with pytest.raises(PromptLayerValidationError, match="exactly one of expected or expected_column"):
+        contains_scorer(expected="refund", expected_column="reference")
     with pytest.raises(PromptLayerValidationError):
         regex_scorer(regex_pattern="")
     with pytest.raises(PromptLayerValidationError):
@@ -189,11 +202,54 @@ def test_predefined_scorer_validation():
     with pytest.raises(PromptLayerValidationError):
         count_scorer(min_count=10, max_count=5)
     with pytest.raises(PromptLayerValidationError):
-        compare_scorer(value_source="")
+        compare_scorer(expected_column="")
+    with pytest.raises(PromptLayerValidationError, match="only one of expected or expected_column"):
+        compare_scorer(expected="refund", expected_column="reference")
     with pytest.raises(PromptLayerValidationError):
         llm_assertion_scorer()
     with pytest.raises(PromptLayerValidationError):
-        trajectory_scorer(value_source="expected", title="")
+        trajectory_scorer(expected_column="expected", title="")
+    with pytest.raises(PromptLayerValidationError, match="legacy parameter"):
+        contains_scorer(value="refund")
+    with pytest.raises(PromptLayerValidationError, match="legacy parameter"):
+        compare_scorer(source="Output")
+    with pytest.raises(PromptLayerValidationError, match="legacy parameter"):
+        trajectory_scorer(accepted_scenarios=[["search"]])
+
+
+def test_compare_scorer_dependencies_support_literal_and_column_targets():
+    from promptlayer.evaluations.validation import scorer_dependencies_from_config
+
+    columns_by_title = {
+        "Output": {"id": "out-1", "title": "Output"},
+        "reference": {"id": "ref-1", "title": "reference"},
+    }
+
+    literal = compare_scorer(expected=None)
+    assert scorer_dependencies_from_config(literal["config"], columns_by_title) == [
+        {
+            "column_id": "out-1",
+            "reference_type": "value",
+            "config_key": "sources",
+            "config_meta": {"position": 0},
+        }
+    ]
+
+    column_target = compare_scorer(expected_column="reference")
+    assert scorer_dependencies_from_config(column_target["config"], columns_by_title) == [
+        {
+            "column_id": "out-1",
+            "reference_type": "value",
+            "config_key": "sources",
+            "config_meta": {"position": 0},
+        },
+        {
+            "column_id": "ref-1",
+            "reference_type": "value",
+            "config_key": "sources",
+            "config_meta": {"position": 1},
+        },
+    ]
 
 
 @pytest.mark.parametrize(
@@ -252,11 +308,11 @@ def test_assert_valid_scorer_validation():
     with pytest.raises(PromptLayerValidationError):
         assert_valid_scorer(type="")
     with pytest.raises(PromptLayerValidationError):
-        assert_valid_scorer(source="")
+        assert_valid_scorer(source_column="")
 
 
 def test_trajectory_scorer_references_trace_for_dependencies():
-    scorer = trajectory_scorer(accepted_scenarios=[["search"]])
+    scorer = trajectory_scorer(expected=[["search"]])
     assert scorers_reference_trace([scorer])
 
 
@@ -274,7 +330,7 @@ def test_trajectory_source_parses_accepted_scenarios():
     assert score_trajectory(matching, {"accepted_scenarios": [["create_folder"]]}) is False
     assert score_trajectory(matching, ["create_folder"]) is False
 
-    scorer = trajectory_scorer(value_source="expected")
+    scorer = trajectory_scorer(expected_column="expected")
     assert scorer["type"] == "TRAJECTORY"
     assert scorer["config"]["trace_source"] == "Trace"
     assert scorer["config"]["expected_source"] == "expected"
@@ -299,7 +355,7 @@ def test_trajectory_source_matches_any_scenario():
 
 def test_trajectory_scorer_accepts_config_accepted_scenarios():
     scorer = trajectory_scorer(
-        accepted_scenarios=[
+        expected=[
             ["get_model_config", "create_prompt"],
             ["list_model_configs", "create_prompt"],
         ],
@@ -313,13 +369,13 @@ def test_trajectory_scorer_accepts_config_accepted_scenarios():
         ],
         "mode": "strict",
     }
-    single = trajectory_scorer(accepted_scenarios=[["search"]], title="one path")
+    single = trajectory_scorer(expected=[["search"]], title="one path")
     assert single["config"]["accepted_scenarios"] == [["search"]]
 
 
 def test_trajectory_scorer_supports_weight_and_failure_threshold():
     scorer = trajectory_scorer(
-        accepted_scenarios=[["search"]],
+        expected=[["search"]],
         weight=2.5,
         failure_threshold=0.5,
         pass_threshold=0.9,
@@ -391,7 +447,7 @@ def test_diagnose_trajectory_failure_categories():
 
 
 def test_trajectory_spec_scorer_references_trace():
-    assert scorers_reference_trace([trajectory_scorer(value_source="expected")])
+    assert scorers_reference_trace([trajectory_scorer(expected_column="expected")])
 
 
 def test_trajectory_tool_order_uses_chronological_not_tree_order():
@@ -444,7 +500,7 @@ def test_diagnose_trajectory_failure_list_expected():
 
 def test_trajectory_scorer_empty_source_mentions_field():
     with pytest.raises(PromptLayerValidationError, match="source"):
-        trajectory_scorer(accepted_scenarios=[["search"]], source="")
+        trajectory_scorer(expected=[["search"]], source_column="")
 
 
 def test_all_predefined_scorers_are_publicly_exported():

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -190,7 +190,7 @@ def test_generic_column_helpers_build_backend_configs():
 
     assertion = llm_assertion_scorer(
         title="quality",
-        source="Output",
+        source_column="Output",
         prompt="Is the answer helpful?",
     )
     assert assertion == {
@@ -199,7 +199,7 @@ def test_generic_column_helpers_build_backend_configs():
         "config": {"source": "Output", "prompt": "Is the answer helpful?"},
     }
 
-    contains = contains_scorer(title="final_answer", source="Output", value="refund")
+    contains = contains_scorer(title="final_answer", source_column="Output", expected="refund")
     assert contains["type"] == "CONTAINS"
     assert contains["config"] == {"source": "Output", "value": "refund"}
 
@@ -208,7 +208,7 @@ def test_generic_column_helpers_build_backend_configs():
     assert compare["config"]["sources"] == ["Output", "expected"]
     assert compare["config"]["comparison_type"] == {"type": "STRING"}
 
-    regex = regex_scorer(title="has_id", source="Output", regex_pattern=r"inv_\d+")
+    regex = regex_scorer(title="has_id", source_column="Output", regex_pattern=r"inv_\d+")
     assert regex["type"] == "REGEX"
     assert regex["config"]["regex_pattern"] == r"inv_\d+"
 
@@ -264,8 +264,8 @@ def test_scorer_dependencies_from_config_resolve_titles():
             "execution_trace": "tr-1",
         },
     }
-    assert _scorers_reference_trace([llm_assertion_scorer(title="x", source="Trace", prompt="ok")])
-    assert not _scorers_reference_trace([llm_assertion_scorer(title="x", source="Output", prompt="ok")])
+    assert _scorers_reference_trace([llm_assertion_scorer(title="x", source_column="Trace", prompt="ok")])
+    assert not _scorers_reference_trace([llm_assertion_scorer(title="x", source_column="Output", prompt="ok")])
     with pytest.raises(PromptLayerValidationError, match="not found: missing"):
         _scorer_dependencies_from_config({"source": "missing"}, columns_by_title)
 
@@ -282,7 +282,7 @@ def test_build_scorecard_steps_persist_column_ids():
         [
             llm_assertion_scorer(
                 title="Response grounded",
-                source="Output",
+                source_column="Output",
                 prompt="User: {user_request}\nTrace: {execution_trace}",
                 variable_mappings={
                     "user_request": "Input",
@@ -305,11 +305,11 @@ def test_build_scorecard_steps_persist_column_ids():
 
 def test_generic_column_helpers_validate_required_fields():
     with pytest.raises(PromptLayerValidationError):
-        llm_assertion_scorer(title="x", source="Output")
+        llm_assertion_scorer(title="x", source_column="Output")
     with pytest.raises(PromptLayerValidationError):
-        contains_scorer(title="x", source="Output")
+        contains_scorer(title="x", source_column="Output")
     with pytest.raises(PromptLayerValidationError):
-        compare_scorer(title="x", value_source="")
+        compare_scorer(title="x", expected_column="")
     with pytest.raises(PromptLayerValidationError):
         code_execution_column("x", code=" ")
 
@@ -338,7 +338,7 @@ def test_column_rejects_text_type_and_reserved_scorer_title():
     with pytest.raises(PromptLayerValidationError, match="cannot be TEXT"):
         column("summary", "TEXT")
     with pytest.raises(PromptLayerValidationError, match="reserved"):
-        contains_scorer(title="Trace", source="Output", value="x")
+        contains_scorer(title="Trace", source_column="Output", expected="x")
 
 
 def exact_match(output, expected):
@@ -744,8 +744,8 @@ def test_eval_runs_inline_dataset_and_writes_rows(
         scorers=[
             compare_scorer(
                 "required_tools",
-                source="Output",
-                value_source="Reference context",
+                source_column="Output",
+                expected_column="Reference context",
             )
         ],
         api_key=promptlayer_api_key,
@@ -916,8 +916,8 @@ def test_eval_creates_supporting_columns_and_runs_operations_before_scorecard(
         scorers=[
             contains_scorer(
                 title="has_name",
-                source="Extracted data",
-                value="ada",
+                source_column="Extracted data",
+                expected="ada",
             )
         ],
         api_key=promptlayer_api_key,
@@ -1077,8 +1077,8 @@ def test_aeval_creates_supporting_columns_and_runs_operations_before_scorecard(
             scorers=[
                 contains_scorer(
                     title="has_name",
-                    source="Extracted data",
-                    value="ada",
+                    source_column="Extracted data",
+                    expected="ada",
                 )
             ],
             api_key=promptlayer_api_key,
@@ -1216,7 +1216,7 @@ def test_eval_resolves_independent_output_and_dataset_tables(
             "scorers": [
                 llm_assertion_scorer(
                     title="quality",
-                    source="Output",
+                    source_column="Output",
                     prompt="ok?",
                 )
             ],
@@ -2369,7 +2369,7 @@ def test_evaluate_raises_rich_trajectory_failure(
             name="Trajectory Evals",
             dataset=[{"input": {"question": "create folder"}, "expected": expected}],
             runner=lambda input_data: "ok",
-            scorers=[trajectory_scorer(value_source="expected", title="trajectory assertions v3")],
+            scorers=[trajectory_scorer(expected_column="expected", title="trajectory assertions v3")],
             api_key=promptlayer_api_key,
             base_url=base_url,
             passing_score=1.0,


### PR DESCRIPTION
## Summary
- rename scorer input parameters to `source_column`, `expected`, and `expected_column`
- support literal and column-backed expected values for compare, contains, and trajectory scorers
- reject removed aliases while preserving backend configuration keys

## Test plan
- [x] `uv run pytest tests/test_eval_scorers.py tests/test_evals.py`
- [x] `uv run ruff check promptlayer/evaluations/scorers tests/test_eval_scorers.py tests/test_evals.py`

Made with [Cursor](https://cursor.com)