### PR TITLE
Add official GenAI provider auto-instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Added official OpenTelemetry auto-instrumentation for OpenAI, Anthropic Messages, and Google GenAI in Gemini and Vertex AI modes.
+- Added official OpenTelemetry auto-instrumentation for OpenAI, Anthropic Messages, Google GenAI in Gemini and Vertex AI modes, and AWS Bedrock through Botocore, including opt-in Bedrock Converse message capture.
 - Added public table scorecard APIs under `client.tables.sheets.scorecards`.
 - Existing `/score` compatibility types now allow scorecard fallback and piggyback recalculation responses.
 - Legacy score configuration deletion is not automatic during migration; `delete_legacy_score` defaults to `False`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added official OpenTelemetry auto-instrumentation for OpenAI, Anthropic Messages, and Google GenAI in Gemini and Vertex AI modes.
 - Added public table scorecard APIs under `client.tables.sheets.scorecards`.
 - Existing `/score` compatibility types now allow scorecard fallback and piggyback recalculation responses.
 - Legacy score configuration deletion is not automatic during migration; `delete_legacy_score` defaults to `False`.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ response = openai.chat.completions.create(
 `PromptLayer(...)` and `AsyncPromptLayer(...)` accept these parameters:
 
 - `api_key: str | None = None`: Your PromptLayer API key. If omitted, the SDK looks for `PROMPTLAYER_API_KEY`.
-- `enable_tracing: bool = False`: Enables OpenTelemetry tracing export to PromptLayer and auto-instruments installed OpenAI, Anthropic, and Google GenAI SDKs when the tracing extra is installed.
+- `enable_tracing: bool = False`: Enables OpenTelemetry tracing export to PromptLayer and auto-instruments installed OpenAI, Anthropic, Google GenAI, and AWS Bedrock SDKs when the tracing extra is installed.
 - `base_url: str | None = None`: Overrides the PromptLayer API base URL. If omitted, the SDK uses `PROMPTLAYER_BASE_URL` or the default API URL.
 - `throw_on_error: bool = True`: Controls whether SDK methods raise PromptLayer exceptions or return `None` for many API errors.
 - `cache_ttl_seconds: int = 0`: Enables in-memory prompt-template caching when greater than `0`.
@@ -145,7 +145,7 @@ Note: When tracing is enabled, spans are exported to PromptLayer using OpenTelem
 Install the tracing extra and the provider SDKs used by your application:
 
 ```bash
-pip install "promptlayer[otel-genai-instrumentation]" openai anthropic google-genai
+pip install "promptlayer[otel-genai-instrumentation]" openai anthropic google-genai boto3
 ```
 
 The extra includes the official OpenTelemetry instrumentors for:
@@ -155,6 +155,7 @@ The extra includes the official OpenTelemetry instrumentors for:
 | OpenAI and Azure OpenAI | Chat Completions, structured-output parsing, Embeddings, and Responses; sync, async, and streaming |
 | Anthropic and Anthropic Vertex | Messages create, parse, and stream; sync and async |
 | Google GenAI | Generate Content, streaming Generate Content, Embeddings, and supported Interactions releases; Gemini Developer API and Vertex AI modes |
+| AWS Bedrock | Botocore Bedrock Runtime Converse and InvokeModel APIs, including streaming |
 
 `PromptLayer(enable_tracing=True)` auto-instruments every supported provider SDK
 that is installed:
@@ -181,12 +182,25 @@ created with `vertexai=True`:
 from promptlayer import configure_tracing
 
 tracer_provider = configure_tracing(
-    providers=("openai", "anthropic", "google"),
+    providers=("openai", "anthropic", "google", "bedrock"),
 )
 ```
 
 The `openai.azure` provider alias selects the underlying OpenAI SDK
-instrumentor.
+instrumentor. The `amazon.bedrock` and `aws.bedrock` aliases select the
+Botocore instrumentor. Because Botocore instrumentation operates at the AWS
+SDK layer, selecting Bedrock also traces other Botocore service calls made by
+the process.
+
+Message bodies are excluded by OpenTelemetry by default. To include prompts
+and responses on PromptLayer request logs, opt in before configuring tracing:
+
+```bash
+export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=SPAN_ONLY
+```
+
+Only enable content capture where sending request and response bodies to your
+configured trace destination is appropriate.
 
 Applications that only use the direct OpenAI SDK can continue to use the
 OpenAI-specific convenience API:

--- a/README.md
+++ b/README.md
@@ -102,12 +102,14 @@ response = openai.chat.completions.create(
 `PromptLayer(...)` and `AsyncPromptLayer(...)` accept these parameters:
 
 - `api_key: str | None = None`: Your PromptLayer API key. If omitted, the SDK looks for `PROMPTLAYER_API_KEY`.
-- `enable_tracing: bool = False`: Enables OpenTelemetry tracing export to PromptLayer and auto-instruments the OpenAI SDK when the tracing extra is installed.
+- `enable_tracing: bool = False`: Enables OpenTelemetry tracing export to PromptLayer and auto-instruments installed OpenAI, Anthropic, and Google GenAI SDKs when the tracing extra is installed.
 - `base_url: str | None = None`: Overrides the PromptLayer API base URL. If omitted, the SDK uses `PROMPTLAYER_BASE_URL` or the default API URL.
 - `throw_on_error: bool = True`: Controls whether SDK methods raise PromptLayer exceptions or return `None` for many API errors.
 - `cache_ttl_seconds: int = 0`: Enables in-memory prompt-template caching when greater than `0`.
 - `tracer_provider: TracerProvider | None = None`: Uses an application-owned OpenTelemetry SDK tracer provider instead
   of the default PromptLayer-managed provider.
+- `tracing_providers: Iterable[str] | None = None`: Selects provider SDKs to auto-instrument. Defaults to all supported
+  providers; pass an empty iterable to export spans without provider SDK auto-instrumentation.
 
 ### Environment Variables
 
@@ -138,35 +140,56 @@ The main resources surfaced by `PromptLayer` and `AsyncPromptLayer` are:
 
 Note: When tracing is enabled, spans are exported to PromptLayer using OpenTelemetry.
 
-### OpenAI SDK Auto-Instrumentation
+### GenAI SDK Auto-Instrumentation
 
-Install the OpenAI-only tracing extra:
+Install the tracing extra and the provider SDKs used by your application:
 
 ```bash
-pip install "promptlayer[otel-genai-instrumentation]" openai
+pip install "promptlayer[otel-genai-instrumentation]" openai anthropic google-genai
 ```
 
-Then enable tracing before making direct OpenAI SDK calls:
+The extra includes the official OpenTelemetry instrumentors for:
+
+| Provider | Instrumented APIs |
+| --- | --- |
+| OpenAI and Azure OpenAI | Chat Completions, structured-output parsing, Embeddings, and Responses; sync, async, and streaming |
+| Anthropic and Anthropic Vertex | Messages create, parse, and stream; sync and async |
+| Google GenAI | Generate Content, streaming Generate Content, Embeddings, and supported Interactions releases; Gemini Developer API and Vertex AI modes |
+
+`PromptLayer(enable_tracing=True)` auto-instruments every supported provider SDK
+that is installed:
 
 ```python
-from openai import OpenAI
+from anthropic import Anthropic
 from promptlayer import PromptLayer
 
 promptlayer_client = PromptLayer(api_key="pl_xxxxx", enable_tracing=True)
-openai_client = OpenAI()
+anthropic_client = Anthropic()
 
-response = openai_client.chat.completions.create(
-    model="gpt-4.1-mini",
+response = anthropic_client.messages.create(
+    model="claude-sonnet-4-20250514",
+    max_tokens=256,
     messages=[{"role": "user", "content": "Say hello."}],
 )
 ```
 
-This preserves the existing PromptLayer-managed tracing provider and additionally
-enables only the official OpenAI SDK instrumentor. It does not instrument the
-OpenAI Agents SDK or any other model provider.
+Advanced OpenTelemetry configurations can select instrumentors explicitly.
+The `google` instrumentor supports both Gemini and `google-genai` clients
+created with `vertexai=True`:
 
-Applications that only use the direct OpenAI SDK can enable the same
-instrumentation without creating a PromptLayer client:
+```python
+from promptlayer import configure_tracing
+
+tracer_provider = configure_tracing(
+    providers=("openai", "anthropic", "google"),
+)
+```
+
+The `openai.azure` provider alias selects the underlying OpenAI SDK
+instrumentor.
+
+Applications that only use the direct OpenAI SDK can continue to use the
+OpenAI-specific convenience API:
 
 ```python
 from openai import OpenAI
@@ -180,8 +203,8 @@ openai_client = OpenAI()
 environment, is safe to call repeatedly with the same tracer provider, and
 returns the configured provider so short-lived processes can flush it.
 
-Applications with advanced OpenTelemetry configuration can continue to use
-`configure_tracing()` directly and pass an application-owned `tracer_provider`.
+All provider instrumentors in this extra require Python 3.10 or newer. The core
+PromptLayer package continues to support Python 3.9 without auto-instrumentation.
 
 ## Table Scorecards
 

--- a/examples/tracing/README.md
+++ b/examples/tracing/README.md
@@ -34,3 +34,17 @@ for Vertex AI use `anthropic`, and Google GenAI clients created with
 Omit `providers` to auto-instrument every supported provider SDK that is
 installed. Pass an empty iterable to configure trace export without provider
 SDK auto-instrumentation.
+
+## Tracing `PromptLayer.run()`
+
+Set the registry prompt name, adjust the example input variables if needed,
+then run:
+
+```bash
+export PROMPTLAYER_PROMPT_NAME="support-answer"
+python examples/tracing/trace_promptlayer_run.py
+```
+
+The trace contains a `PromptLayer Run` parent with sibling
+`Prompt template fetch` and provider LLM-call children. Provider
+auto-instrumentation requires Python 3.10 or newer.

--- a/examples/tracing/README.md
+++ b/examples/tracing/README.md
@@ -6,7 +6,7 @@ with PromptLayer.
 Install the tracing extra and the provider SDKs you use:
 
 ```bash
-pip install "promptlayer[otel-genai-instrumentation]" openai anthropic google-genai
+pip install "promptlayer[otel-genai-instrumentation]" openai anthropic google-genai boto3
 ```
 
 Set `PROMPTLAYER_API_KEY` and the provider's standard API-key environment
@@ -16,6 +16,7 @@ variable, then run its example:
 python examples/tracing/trace_openai.py
 python examples/tracing/trace_anthropic.py
 python examples/tracing/trace_google_genai.py
+python examples/tracing/trace_bedrock.py
 ```
 
 Each example configures its provider before making a normal SDK request:
@@ -26,10 +27,12 @@ from promptlayer import configure_tracing
 tracer_provider = configure_tracing(providers=("openai",))
 ```
 
-Supported selectors are `openai`, `anthropic`, and `google`. The
+Supported selectors are `openai`, `anthropic`, `google`, and `bedrock`. The
 `openai.azure` alias uses the OpenAI instrumentor. Anthropic clients configured
 for Vertex AI use `anthropic`, and Google GenAI clients created with
-`vertexai=True` use `google`.
+`vertexai=True` use `google`. The `amazon.bedrock` and `aws.bedrock` aliases use
+the Botocore instrumentor, which also traces other Botocore service calls made
+by the process.
 
 Omit `providers` to auto-instrument every supported provider SDK that is
 installed. Pass an empty iterable to configure trace export without provider
@@ -48,3 +51,8 @@ python examples/tracing/trace_promptlayer_run.py
 The trace contains a `PromptLayer Run` parent with sibling
 `Prompt template fetch` and provider LLM-call children. Provider
 auto-instrumentation requires Python 3.10 or newer.
+
+OpenTelemetry excludes message bodies by default. Set
+`OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=SPAN_ONLY` before tracing
+when PromptLayer should receive prompt and response content. The Bedrock
+example enables this explicitly.

--- a/examples/tracing/README.md
+++ b/examples/tracing/README.md
@@ -1,0 +1,36 @@
+# Provider auto-instrumentation examples
+
+These examples show the minimum setup for tracing direct provider SDK calls
+with PromptLayer.
+
+Install the tracing extra and the provider SDKs you use:
+
+```bash
+pip install "promptlayer[otel-genai-instrumentation]" openai anthropic google-genai
+```
+
+Set `PROMPTLAYER_API_KEY` and the provider's standard API-key environment
+variable, then run its example:
+
+```bash
+python examples/tracing/trace_openai.py
+python examples/tracing/trace_anthropic.py
+python examples/tracing/trace_google_genai.py
+```
+
+Each example configures its provider before making a normal SDK request:
+
+```python
+from promptlayer import configure_tracing
+
+tracer_provider = configure_tracing(providers=("openai",))
+```
+
+Supported selectors are `openai`, `anthropic`, and `google`. The
+`openai.azure` alias uses the OpenAI instrumentor. Anthropic clients configured
+for Vertex AI use `anthropic`, and Google GenAI clients created with
+`vertexai=True` use `google`.
+
+Omit `providers` to auto-instrument every supported provider SDK that is
+installed. Pass an empty iterable to configure trace export without provider
+SDK auto-instrumentation.

--- a/examples/tracing/trace_anthropic.py
+++ b/examples/tracing/trace_anthropic.py
@@ -1,0 +1,23 @@
+"""Configure PromptLayer auto-instrumentation for the Anthropic SDK."""
+
+import os
+
+from anthropic import Anthropic
+
+from promptlayer import configure_tracing
+
+tracer_provider = configure_tracing(providers=("anthropic",))
+client = Anthropic()
+model = os.environ.get("ANTHROPIC_MODEL", "claude-haiku-4-5")
+
+
+try:
+    response = client.messages.create(
+        model=model,
+        max_tokens=128,
+        messages=[{"role": "user", "content": "Explain distributed tracing in one sentence."}],
+    )
+    print(response.content[0].text)
+finally:
+    client.close()
+    tracer_provider.force_flush()

--- a/examples/tracing/trace_bedrock.py
+++ b/examples/tracing/trace_bedrock.py
@@ -1,0 +1,31 @@
+"""Configure PromptLayer auto-instrumentation for raw AWS Bedrock calls."""
+
+import os
+
+import boto3
+
+from promptlayer import configure_tracing
+
+os.environ.setdefault("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "SPAN_ONLY")
+tracer_provider = configure_tracing(providers=("bedrock",))
+client = boto3.client(
+    "bedrock-runtime",
+    region_name=os.environ.get("AWS_REGION", "us-east-1"),
+)
+model = os.environ.get("AWS_BEDROCK_MODEL", "global.anthropic.claude-sonnet-5")
+
+
+try:
+    response = client.converse(
+        modelId=model,
+        messages=[
+            {
+                "role": "user",
+                "content": [{"text": "Explain distributed tracing in one sentence."}],
+            }
+        ],
+        inferenceConfig={"maxTokens": 128},
+    )
+    print(response["output"]["message"]["content"][0]["text"])
+finally:
+    tracer_provider.force_flush()

--- a/examples/tracing/trace_google_genai.py
+++ b/examples/tracing/trace_google_genai.py
@@ -1,0 +1,22 @@
+"""Configure PromptLayer auto-instrumentation for the Google GenAI SDK."""
+
+import os
+
+from google import genai
+
+from promptlayer import configure_tracing
+
+tracer_provider = configure_tracing(providers=("google",))
+client = genai.Client(api_key=os.environ["GOOGLE_API_KEY"])
+model = os.environ.get("GOOGLE_GENAI_MODEL", "gemini-2.5-flash")
+
+
+try:
+    response = client.models.generate_content(
+        model=model,
+        contents="Explain distributed tracing in one sentence.",
+    )
+    print(response.text)
+finally:
+    client.close()
+    tracer_provider.force_flush()

--- a/examples/tracing/trace_openai.py
+++ b/examples/tracing/trace_openai.py
@@ -1,4 +1,4 @@
-"""Trace OpenAI Chat Completions and Responses calls and export them to PromptLayer."""
+"""Configure PromptLayer auto-instrumentation for the OpenAI SDK."""
 
 import os
 
@@ -8,18 +8,15 @@ from promptlayer import configure_tracing
 
 tracer_provider = configure_tracing(providers=("openai",))
 client = OpenAI()
+model = os.environ.get("OPENAI_MODEL", "gpt-4.1-mini")
+
 
 try:
-    chat_completion = client.chat.completions.create(
-        model=os.environ["OPENAI_MODEL"],
+    response = client.chat.completions.create(
+        model=model,
         messages=[{"role": "user", "content": "Explain distributed tracing in one sentence."}],
     )
-    print("Chat Completions:", chat_completion.choices[0].message.content)
-
-    response = client.responses.create(
-        model=os.environ["OPENAI_MODEL"],
-        input="Explain distributed tracing in one sentence.",
-    )
-    print("Responses:", response.output_text)
+    print(response.choices[0].message.content)
 finally:
+    client.close()
     tracer_provider.force_flush()

--- a/examples/tracing/trace_promptlayer_run.py
+++ b/examples/tracing/trace_promptlayer_run.py
@@ -1,0 +1,18 @@
+"""Trace a PromptLayer prompt-template run."""
+
+import os
+
+from promptlayer import PromptLayer
+
+promptlayer = PromptLayer(enable_tracing=True)
+
+try:
+    result = promptlayer.run(
+        prompt_name=os.environ["PROMPTLAYER_PROMPT_NAME"],
+        input_variables={"question": "Explain distributed tracing in one sentence."},
+        metadata={"example": "promptlayer.run"},
+    )
+    print(result["raw_response"])
+finally:
+    if promptlayer.tracer_provider is not None:
+        promptlayer.tracer_provider.force_flush()

--- a/poetry.lock
+++ b/poetry.lock
@@ -1770,26 +1770,71 @@ packaging = ">=18.0"
 wrapt = ">=1.0.0,<3.0.0"
 
 [[package]]
-name = "opentelemetry-instrumentation-openai-v2"
-version = "2.4b0"
+name = "opentelemetry-instrumentation-genai-anthropic"
+version = "1.0b0"
+description = "OpenTelemetry Anthropic instrumentation"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"otel-genai-instrumentation\" and python_version >= \"3.10\""
+files = [
+    {file = "opentelemetry_instrumentation_genai_anthropic-1.0b0-py3-none-any.whl", hash = "sha256:5e5bd44df5a502f54222aee07502d8cf888ef5ad797500865acaad891d0c036a"},
+    {file = "opentelemetry_instrumentation_genai_anthropic-1.0b0.tar.gz", hash = "sha256:7849e0615e6b7424f683b90bfef90765bed611e1d053a4202eb3b1d7ad08aa91"},
+]
+
+[package.dependencies]
+opentelemetry-api = ">=1.43,<2.0"
+opentelemetry-instrumentation = ">=0.64b0,<1.0"
+opentelemetry-semantic-conventions = ">=0.64b0,<1.0"
+opentelemetry-util-genai = ">=1.0b0.dev"
+
+[package.extras]
+instruments = ["anthropic (>=0.51.0)"]
+
+[[package]]
+name = "opentelemetry-instrumentation-genai-openai"
+version = "1.0b0"
 description = "OpenTelemetry Official OpenAI instrumentation"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
 markers = "extra == \"otel-genai-instrumentation\" and python_version >= \"3.10\""
 files = [
-    {file = "opentelemetry_instrumentation_openai_v2-2.4b0-py3-none-any.whl", hash = "sha256:c0c65fe4593fdcb466b55c047138ec71d28a5a3f36c3f0c2c5738343daa31d5c"},
-    {file = "opentelemetry_instrumentation_openai_v2-2.4b0.tar.gz", hash = "sha256:571a2febd05b15808d7c777455d5a74c9abe08c694cb9827a98c5b4258f2adf1"},
+    {file = "opentelemetry_instrumentation_genai_openai-1.0b0-py3-none-any.whl", hash = "sha256:e84d66c8605a11cfb3ab65403e86483fb7017787c64959e200ac7cd6d6c1693a"},
+    {file = "opentelemetry_instrumentation_genai_openai-1.0b0.tar.gz", hash = "sha256:2177c2d8b2073dd0043c33b59f5f8e26bfe8f39a3121ca4c41530629e214c3a8"},
 ]
 
 [package.dependencies]
-opentelemetry-api = ">=1.39,<2.0"
-opentelemetry-instrumentation = ">=0.60b0,<1.0"
-opentelemetry-semantic-conventions = ">=0.60b0,<1.0"
-opentelemetry-util-genai = ">=0.4b0.dev"
+opentelemetry-api = ">=1.43,<2.0"
+opentelemetry-instrumentation = ">=0.64b0,<1.0"
+opentelemetry-semantic-conventions = ">=0.64b0,<1.0"
+opentelemetry-util-genai = ">=1.0b0.dev"
 
 [package.extras]
 instruments = ["openai (>=1.26.0)"]
+
+[[package]]
+name = "opentelemetry-instrumentation-google-genai"
+version = "1.0b1"
+description = "OpenTelemetry"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"otel-genai-instrumentation\" and python_version >= \"3.10\""
+files = [
+    {file = "opentelemetry_instrumentation_google_genai-1.0b1-py3-none-any.whl", hash = "sha256:50789eebf4ce38dc09147e28bdbd96d45550c7f479232c593c0ddbdab37cf97f"},
+    {file = "opentelemetry_instrumentation_google_genai-1.0b1.tar.gz", hash = "sha256:784b3a473ed51033837114b96854b31a0f0b0fe7c81e132e58a45352eee3b102"},
+]
+
+[package.dependencies]
+opentelemetry-api = ">=1.43,<2.0"
+opentelemetry-instrumentation = ">=0.64b0,<1"
+opentelemetry-semantic-conventions = ">=0.64b0,<1"
+opentelemetry-util-genai = ">=1.0b0,<2"
+wrapt = ">=1.17.0,<3.0.0"
+
+[package.extras]
+instruments = ["google-genai (>=1.32.0,<3)"]
 
 [[package]]
 name = "opentelemetry-processor-baggage"
@@ -3137,6 +3182,7 @@ description = "Module for decorators, wrappers and monkey patching."
 optional = false
 python-versions = ">=3.6"
 groups = ["main", "dev"]
+markers = "python_version == \"3.9\""
 files = [
     {file = "wrapt-1.16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ffa565331890b90056c01db69c0fe634a776f8019c143a5ae265f9c6bc4bd6d4"},
     {file = "wrapt-1.16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e4fdb9275308292e880dcbeb12546df7f3e0f96c6b41197e0cf37d2826359020"},
@@ -3209,7 +3255,98 @@ files = [
     {file = "wrapt-1.16.0-py3-none-any.whl", hash = "sha256:6906c4100a8fcbf2fa735f6059214bb13b97f75b1a61777fcf6432121ef12ef1"},
     {file = "wrapt-1.16.0.tar.gz", hash = "sha256:5f370f952971e7d17c7d1ead40e49f32345a7f7a5373571ef44d800d06b1899d"},
 ]
-markers = {main = "extra == \"otel-genai-instrumentation\" or python_version == \"3.9\""}
+
+[[package]]
+name = "wrapt"
+version = "1.17.3"
+description = "Module for decorators, wrappers and monkey patching."
+optional = false
+python-versions = ">=3.8"
+groups = ["main", "dev"]
+files = [
+    {file = "wrapt-1.17.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:88bbae4d40d5a46142e70d58bf664a89b6b4befaea7b2ecc14e03cedb8e06c04"},
+    {file = "wrapt-1.17.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e6b13af258d6a9ad602d57d889f83b9d5543acd471eee12eb51f5b01f8eb1bc2"},
+    {file = "wrapt-1.17.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fd341868a4b6714a5962c1af0bd44f7c404ef78720c7de4892901e540417111c"},
+    {file = "wrapt-1.17.3-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f9b2601381be482f70e5d1051a5965c25fb3625455a2bf520b5a077b22afb775"},
+    {file = "wrapt-1.17.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:343e44b2a8e60e06a7e0d29c1671a0d9951f59174f3709962b5143f60a2a98bd"},
+    {file = "wrapt-1.17.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:33486899acd2d7d3066156b03465b949da3fd41a5da6e394ec49d271baefcf05"},
+    {file = "wrapt-1.17.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e6f40a8aa5a92f150bdb3e1c44b7e98fb7113955b2e5394122fa5532fec4b418"},
+    {file = "wrapt-1.17.3-cp310-cp310-win32.whl", hash = "sha256:a36692b8491d30a8c75f1dfee65bef119d6f39ea84ee04d9f9311f83c5ad9390"},
+    {file = "wrapt-1.17.3-cp310-cp310-win_amd64.whl", hash = "sha256:afd964fd43b10c12213574db492cb8f73b2f0826c8df07a68288f8f19af2ebe6"},
+    {file = "wrapt-1.17.3-cp310-cp310-win_arm64.whl", hash = "sha256:af338aa93554be859173c39c85243970dc6a289fa907402289eeae7543e1ae18"},
+    {file = "wrapt-1.17.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:273a736c4645e63ac582c60a56b0acb529ef07f78e08dc6bfadf6a46b19c0da7"},
+    {file = "wrapt-1.17.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5531d911795e3f935a9c23eb1c8c03c211661a5060aab167065896bbf62a5f85"},
+    {file = "wrapt-1.17.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0610b46293c59a3adbae3dee552b648b984176f8562ee0dba099a56cfbe4df1f"},
+    {file = "wrapt-1.17.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b32888aad8b6e68f83a8fdccbf3165f5469702a7544472bdf41f582970ed3311"},
+    {file = "wrapt-1.17.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cccf4f81371f257440c88faed6b74f1053eef90807b77e31ca057b2db74edb1"},
+    {file = "wrapt-1.17.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8a210b158a34164de8bb68b0e7780041a903d7b00c87e906fb69928bf7890d5"},
+    {file = "wrapt-1.17.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:79573c24a46ce11aab457b472efd8d125e5a51da2d1d24387666cd85f54c05b2"},
+    {file = "wrapt-1.17.3-cp311-cp311-win32.whl", hash = "sha256:c31eebe420a9a5d2887b13000b043ff6ca27c452a9a22fa71f35f118e8d4bf89"},
+    {file = "wrapt-1.17.3-cp311-cp311-win_amd64.whl", hash = "sha256:0b1831115c97f0663cb77aa27d381237e73ad4f721391a9bfb2fe8bc25fa6e77"},
+    {file = "wrapt-1.17.3-cp311-cp311-win_arm64.whl", hash = "sha256:5a7b3c1ee8265eb4c8f1b7d29943f195c00673f5ab60c192eba2d4a7eae5f46a"},
+    {file = "wrapt-1.17.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ab232e7fdb44cdfbf55fc3afa31bcdb0d8980b9b95c38b6405df2acb672af0e0"},
+    {file = "wrapt-1.17.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9baa544e6acc91130e926e8c802a17f3b16fbea0fd441b5a60f5cf2cc5c3deba"},
+    {file = "wrapt-1.17.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6b538e31eca1a7ea4605e44f81a48aa24c4632a277431a6ed3f328835901f4fd"},
+    {file = "wrapt-1.17.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:042ec3bb8f319c147b1301f2393bc19dba6e176b7da446853406d041c36c7828"},
+    {file = "wrapt-1.17.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3af60380ba0b7b5aeb329bc4e402acd25bd877e98b3727b0135cb5c2efdaefe9"},
+    {file = "wrapt-1.17.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0b02e424deef65c9f7326d8c19220a2c9040c51dc165cddb732f16198c168396"},
+    {file = "wrapt-1.17.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:74afa28374a3c3a11b3b5e5fca0ae03bef8450d6aa3ab3a1e2c30e3a75d023dc"},
+    {file = "wrapt-1.17.3-cp312-cp312-win32.whl", hash = "sha256:4da9f45279fff3543c371d5ababc57a0384f70be244de7759c85a7f989cb4ebe"},
+    {file = "wrapt-1.17.3-cp312-cp312-win_amd64.whl", hash = "sha256:e71d5c6ebac14875668a1e90baf2ea0ef5b7ac7918355850c0908ae82bcb297c"},
+    {file = "wrapt-1.17.3-cp312-cp312-win_arm64.whl", hash = "sha256:604d076c55e2fdd4c1c03d06dc1a31b95130010517b5019db15365ec4a405fc6"},
+    {file = "wrapt-1.17.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a47681378a0439215912ef542c45a783484d4dd82bac412b71e59cf9c0e1cea0"},
+    {file = "wrapt-1.17.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:54a30837587c6ee3cd1a4d1c2ec5d24e77984d44e2f34547e2323ddb4e22eb77"},
+    {file = "wrapt-1.17.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:16ecf15d6af39246fe33e507105d67e4b81d8f8d2c6598ff7e3ca1b8a37213f7"},
+    {file = "wrapt-1.17.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6fd1ad24dc235e4ab88cda009e19bf347aabb975e44fd5c2fb22a3f6e4141277"},
+    {file = "wrapt-1.17.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ed61b7c2d49cee3c027372df5809a59d60cf1b6c2f81ee980a091f3afed6a2d"},
+    {file = "wrapt-1.17.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:423ed5420ad5f5529db9ce89eac09c8a2f97da18eb1c870237e84c5a5c2d60aa"},
+    {file = "wrapt-1.17.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e01375f275f010fcbf7f643b4279896d04e571889b8a5b3f848423d91bf07050"},
+    {file = "wrapt-1.17.3-cp313-cp313-win32.whl", hash = "sha256:53e5e39ff71b3fc484df8a522c933ea2b7cdd0d5d15ae82e5b23fde87d44cbd8"},
+    {file = "wrapt-1.17.3-cp313-cp313-win_amd64.whl", hash = "sha256:1f0b2f40cf341ee8cc1a97d51ff50dddb9fcc73241b9143ec74b30fc4f44f6cb"},
+    {file = "wrapt-1.17.3-cp313-cp313-win_arm64.whl", hash = "sha256:7425ac3c54430f5fc5e7b6f41d41e704db073309acfc09305816bc6a0b26bb16"},
+    {file = "wrapt-1.17.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cf30f6e3c077c8e6a9a7809c94551203c8843e74ba0c960f4a98cd80d4665d39"},
+    {file = "wrapt-1.17.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e228514a06843cae89621384cfe3a80418f3c04aadf8a3b14e46a7be704e4235"},
+    {file = "wrapt-1.17.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5ea5eb3c0c071862997d6f3e02af1d055f381b1d25b286b9d6644b79db77657c"},
+    {file = "wrapt-1.17.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:281262213373b6d5e4bb4353bc36d1ba4084e6d6b5d242863721ef2bf2c2930b"},
+    {file = "wrapt-1.17.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4a8d2b25efb6681ecacad42fca8859f88092d8732b170de6a5dddd80a1c8fa"},
+    {file = "wrapt-1.17.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:373342dd05b1d07d752cecbec0c41817231f29f3a89aa8b8843f7b95992ed0c7"},
+    {file = "wrapt-1.17.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d40770d7c0fd5cbed9d84b2c3f2e156431a12c9a37dc6284060fb4bec0b7ffd4"},
+    {file = "wrapt-1.17.3-cp314-cp314-win32.whl", hash = "sha256:fbd3c8319de8e1dc79d346929cd71d523622da527cca14e0c1d257e31c2b8b10"},
+    {file = "wrapt-1.17.3-cp314-cp314-win_amd64.whl", hash = "sha256:e1a4120ae5705f673727d3253de3ed0e016f7cd78dc463db1b31e2463e1f3cf6"},
+    {file = "wrapt-1.17.3-cp314-cp314-win_arm64.whl", hash = "sha256:507553480670cab08a800b9463bdb881b2edeed77dc677b0a5915e6106e91a58"},
+    {file = "wrapt-1.17.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:ed7c635ae45cfbc1a7371f708727bf74690daedc49b4dba310590ca0bd28aa8a"},
+    {file = "wrapt-1.17.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:249f88ed15503f6492a71f01442abddd73856a0032ae860de6d75ca62eed8067"},
+    {file = "wrapt-1.17.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a03a38adec8066d5a37bea22f2ba6bbf39fcdefbe2d91419ab864c3fb515454"},
+    {file = "wrapt-1.17.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5d4478d72eb61c36e5b446e375bbc49ed002430d17cdec3cecb36993398e1a9e"},
+    {file = "wrapt-1.17.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223db574bb38637e8230eb14b185565023ab624474df94d2af18f1cdb625216f"},
+    {file = "wrapt-1.17.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e405adefb53a435f01efa7ccdec012c016b5a1d3f35459990afc39b6be4d5056"},
+    {file = "wrapt-1.17.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:88547535b787a6c9ce4086917b6e1d291aa8ed914fdd3a838b3539dc95c12804"},
+    {file = "wrapt-1.17.3-cp314-cp314t-win32.whl", hash = "sha256:41b1d2bc74c2cac6f9074df52b2efbef2b30bdfe5f40cb78f8ca22963bc62977"},
+    {file = "wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116"},
+    {file = "wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6"},
+    {file = "wrapt-1.17.3-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:70d86fa5197b8947a2fa70260b48e400bf2ccacdcab97bb7de47e3d1e6312225"},
+    {file = "wrapt-1.17.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:df7d30371a2accfe4013e90445f6388c570f103d61019b6b7c57e0265250072a"},
+    {file = "wrapt-1.17.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:caea3e9c79d5f0d2c6d9ab96111601797ea5da8e6d0723f77eabb0d4068d2b2f"},
+    {file = "wrapt-1.17.3-cp38-cp38-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:758895b01d546812d1f42204bd443b8c433c44d090248bf22689df673ccafe00"},
+    {file = "wrapt-1.17.3-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02b551d101f31694fc785e58e0720ef7d9a10c4e62c1c9358ce6f63f23e30a56"},
+    {file = "wrapt-1.17.3-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:656873859b3b50eeebe6db8b1455e99d90c26ab058db8e427046dbc35c3140a5"},
+    {file = "wrapt-1.17.3-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:a9a2203361a6e6404f80b99234fe7fb37d1fc73487b5a78dc1aa5b97201e0f22"},
+    {file = "wrapt-1.17.3-cp38-cp38-win32.whl", hash = "sha256:55cbbc356c2842f39bcc553cf695932e8b30e30e797f961860afb308e6b1bb7c"},
+    {file = "wrapt-1.17.3-cp38-cp38-win_amd64.whl", hash = "sha256:ad85e269fe54d506b240d2d7b9f5f2057c2aa9a2ea5b32c66f8902f768117ed2"},
+    {file = "wrapt-1.17.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:30ce38e66630599e1193798285706903110d4f057aab3168a34b7fdc85569afc"},
+    {file = "wrapt-1.17.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:65d1d00fbfb3ea5f20add88bbc0f815150dbbde3b026e6c24759466c8b5a9ef9"},
+    {file = "wrapt-1.17.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a7c06742645f914f26c7f1fa47b8bc4c91d222f76ee20116c43d5ef0912bba2d"},
+    {file = "wrapt-1.17.3-cp39-cp39-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7e18f01b0c3e4a07fe6dfdb00e29049ba17eadbc5e7609a2a3a4af83ab7d710a"},
+    {file = "wrapt-1.17.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f5f51a6466667a5a356e6381d362d259125b57f059103dd9fdc8c0cf1d14139"},
+    {file = "wrapt-1.17.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:59923aa12d0157f6b82d686c3fd8e1166fa8cdfb3e17b42ce3b6147ff81528df"},
+    {file = "wrapt-1.17.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:46acc57b331e0b3bcb3e1ca3b421d65637915cfcd65eb783cb2f78a511193f9b"},
+    {file = "wrapt-1.17.3-cp39-cp39-win32.whl", hash = "sha256:3e62d15d3cfa26e3d0788094de7b64efa75f3a53875cdbccdf78547aed547a81"},
+    {file = "wrapt-1.17.3-cp39-cp39-win_amd64.whl", hash = "sha256:1f23fa283f51c890eda8e34e4937079114c74b4c81d2b2f1f1d94948f5cc3d7f"},
+    {file = "wrapt-1.17.3-cp39-cp39-win_arm64.whl", hash = "sha256:24c2ed34dc222ed754247a2702b1e1e89fdbaa4016f324b4b8f1a802d4ffe87f"},
+    {file = "wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22"},
+    {file = "wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0"},
+]
+markers = {main = "extra == \"otel-genai-instrumentation\" and python_version >= \"3.10\"", dev = "python_version >= \"3.10\""}
 
 [[package]]
 name = "yarl"
@@ -3344,9 +3481,9 @@ test = ["big-O", "importlib-resources ; python_version < \"3.9\"", "jaraco.funct
 [extras]
 claude-agents = ["claude-agent-sdk"]
 openai-agents = ["eval-type-backport", "openai-agents"]
-otel-genai-instrumentation = ["opentelemetry-instrumentation-openai-v2"]
+otel-genai-instrumentation = ["opentelemetry-instrumentation-genai-anthropic", "opentelemetry-instrumentation-genai-openai", "opentelemetry-instrumentation-google-genai"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "763dc9c4bbb0c0ea50478a26e609fa933fa9109c61db01737b4697d349e7cab6"
+content-hash = "b160105a79e887ee6934c9a0ad8576fa8cb366510dade365b151c1b04f256391"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1805,6 +1805,29 @@ packaging = ">=18.0"
 wrapt = ">=1.0.0,<3.0.0"
 
 [[package]]
+name = "opentelemetry-instrumentation-botocore"
+version = "0.65b0"
+description = "OpenTelemetry Botocore instrumentation"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"otel-genai-instrumentation\" and python_version >= \"3.10\""
+files = [
+    {file = "opentelemetry_instrumentation_botocore-0.65b0-py3-none-any.whl", hash = "sha256:a5e80b9423f8369c9bbc27a64b31f02cc44218633028ad8d1ace0a2a7fc8f4cd"},
+    {file = "opentelemetry_instrumentation_botocore-0.65b0.tar.gz", hash = "sha256:64987326ac98a47a85821606a981f5058864de0e98b43c8de892eb0fe625b04e"},
+]
+
+[package.dependencies]
+opentelemetry-api = ">=1.37,<2.0"
+opentelemetry-instrumentation = "0.65b0"
+opentelemetry-propagator-aws-xray = ">=1.0,<2.0"
+opentelemetry-semantic-conventions = "0.65b0"
+wrapt = ">=1.0.0,<3.0.0"
+
+[package.extras]
+instruments-any = ["aiobotocore (>=2.0,<4.0)", "botocore (>=1.0,<2.0)"]
+
+[[package]]
 name = "opentelemetry-instrumentation-genai-anthropic"
 version = "1.0b0"
 description = "OpenTelemetry Anthropic instrumentation"
@@ -1887,6 +1910,22 @@ files = [
 opentelemetry-api = ">=1.5,<2.0"
 opentelemetry-sdk = ">=1.5,<2.0"
 wrapt = ">=1.0.0,<2.0.0"
+
+[[package]]
+name = "opentelemetry-propagator-aws-xray"
+version = "1.0.2"
+description = "AWS X-Ray Propagator for OpenTelemetry"
+optional = true
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "extra == \"otel-genai-instrumentation\" and python_version >= \"3.10\""
+files = [
+    {file = "opentelemetry_propagator_aws_xray-1.0.2-py3-none-any.whl", hash = "sha256:1c99181ee228e99bddb638a0c911a297fa21f1c3a0af951f841e79919b5f1934"},
+    {file = "opentelemetry_propagator_aws_xray-1.0.2.tar.gz", hash = "sha256:6b2cee5479d2ef0172307b66ed2ed151f598a0fd29b3c01133ac87ca06326260"},
+]
+
+[package.dependencies]
+opentelemetry-api = ">=1.12,<2.0"
 
 [[package]]
 name = "opentelemetry-proto"
@@ -3435,9 +3474,9 @@ test = ["big-O", "importlib-resources ; python_version < \"3.9\"", "jaraco.funct
 [extras]
 claude-agents = ["claude-agent-sdk"]
 openai-agents = ["eval-type-backport", "openai-agents"]
-otel-genai-instrumentation = ["opentelemetry-instrumentation-genai-anthropic", "opentelemetry-instrumentation-genai-openai", "opentelemetry-instrumentation-google-genai"]
+otel-genai-instrumentation = ["opentelemetry-instrumentation-botocore", "opentelemetry-instrumentation-genai-anthropic", "opentelemetry-instrumentation-genai-openai", "opentelemetry-instrumentation-google-genai"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "ef811114d9433e0c7b69fd271d0e287b5ec4982445ade6e05596c1094dbdbd00"
+content-hash = "38b1f69478aafea91107f4707b11af35af122db85a12b6a632f33ad43c81ba04"

--- a/promptlayer/__init__.py
+++ b/promptlayer/__init__.py
@@ -36,7 +36,7 @@ from .exceptions import (
 from .promptlayer import AsyncPromptLayer, PromptLayer
 from .tracing import NATIVE_OTEL_PROVIDERS, configure_tracing, instrument_openai
 
-__version__ = "1.5.4"
+__version__ = "1.5.5"
 __all__ = [
     "PromptLayer",
     "AsyncPromptLayer",

--- a/promptlayer/integrations/bedrock.py
+++ b/promptlayer/integrations/bedrock.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+from typing import Any, Dict, Iterable, List, Optional
+
+logger = logging.getLogger(__name__)
+
+_BEDROCK_RUNTIME_SERVICE = "bedrock-runtime"
+_CONVERSE_OPERATIONS = {"Converse", "ConverseStream"}
+_GEN_AI_INPUT_MESSAGES = "gen_ai.input.messages"
+_GEN_AI_OUTPUT_MESSAGES = "gen_ai.output.messages"
+_GEN_AI_SYSTEM_INSTRUCTIONS = "gen_ai.system_instructions"
+_MESSAGE_CONTENT_ENV = "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"
+_SPAN_CAPTURE_MODES = {
+    "1",
+    "on",
+    "span",
+    "span_only",
+    "span_and_event",
+    "true",
+    "yes",
+}
+
+
+def bedrock_request_hook(
+    span: Any,
+    service_name: str,
+    operation_name: str,
+    api_params: Dict[str, Any],
+) -> None:
+    """Attach Bedrock Converse input content using GenAI span conventions."""
+
+    if not _should_capture(span, service_name, operation_name):
+        return
+
+    try:
+        messages = _normalize_messages(api_params.get("messages", ()))
+        if messages:
+            _set_json_attribute(span, _GEN_AI_INPUT_MESSAGES, messages)
+
+        system_instructions = _normalize_parts(api_params.get("system", ()))
+        if system_instructions:
+            _set_json_attribute(span, _GEN_AI_SYSTEM_INSTRUCTIONS, system_instructions)
+    except Exception:
+        logger.debug("PromptLayer could not capture an AWS Bedrock request body", exc_info=True)
+
+
+def bedrock_response_hook(
+    span: Any,
+    service_name: str,
+    operation_name: str,
+    result: Optional[Dict[str, Any]],
+) -> None:
+    """Attach a non-streaming Bedrock Converse response to its GenAI span."""
+
+    if not _should_capture(span, service_name, operation_name) or not isinstance(result, dict):
+        return
+
+    try:
+        output = result.get("output")
+        message = output.get("message") if isinstance(output, dict) else None
+        normalized = _normalize_message(message, default_role="assistant")
+        if normalized is None:
+            return
+
+        finish_reason = result.get("stopReason")
+        if finish_reason is not None:
+            normalized["finish_reason"] = str(finish_reason)
+        _set_json_attribute(span, _GEN_AI_OUTPUT_MESSAGES, [normalized])
+    except Exception:
+        logger.debug("PromptLayer could not capture an AWS Bedrock response body", exc_info=True)
+
+
+def _should_capture(span: Any, service_name: str, operation_name: str) -> bool:
+    if service_name != _BEDROCK_RUNTIME_SERVICE or operation_name not in _CONVERSE_OPERATIONS:
+        return False
+    if not _capture_message_content_enabled():
+        return False
+    is_recording = getattr(span, "is_recording", None)
+    return not callable(is_recording) or is_recording()
+
+
+def _capture_message_content_enabled() -> bool:
+    configured = os.environ.get(_MESSAGE_CONTENT_ENV, "")
+    return configured.strip().lower() in _SPAN_CAPTURE_MODES
+
+
+def _normalize_messages(messages: Any) -> List[Dict[str, Any]]:
+    if not isinstance(messages, Iterable) or isinstance(messages, (str, bytes, dict)):
+        return []
+
+    normalized = []
+    for message in messages:
+        normalized_message = _normalize_message(message)
+        if normalized_message is not None:
+            normalized.append(normalized_message)
+    return normalized
+
+
+def _normalize_message(message: Any, *, default_role: Optional[str] = None) -> Optional[Dict[str, Any]]:
+    if not isinstance(message, dict):
+        return None
+
+    role = message.get("role") or default_role
+    parts = _normalize_parts(message.get("content", ()))
+    if not role or not parts:
+        return None
+    return {"role": str(role), "parts": parts}
+
+
+def _normalize_parts(content: Any) -> List[Dict[str, Any]]:
+    if isinstance(content, (str, bytes)) or isinstance(content, dict):
+        content = [content]
+    if not isinstance(content, Iterable):
+        return []
+
+    parts = []
+    for block in content:
+        part = _normalize_part(block)
+        if part is not None:
+            parts.append(part)
+    return parts
+
+
+def _normalize_part(block: Any) -> Optional[Dict[str, Any]]:
+    if isinstance(block, str):
+        return {"type": "text", "content": block}
+    if isinstance(block, bytes):
+        return {
+            "type": "generic",
+            "value": base64.b64encode(block).decode("ascii"),
+        }
+    if not isinstance(block, dict):
+        return None
+
+    if "text" in block:
+        return {"type": "text", "content": str(block["text"])}
+
+    tool_use = block.get("toolUse")
+    if isinstance(tool_use, dict):
+        return {
+            "type": "tool_call",
+            "id": tool_use.get("toolUseId"),
+            "name": tool_use.get("name", ""),
+            "arguments": _json_safe(tool_use.get("input")),
+        }
+
+    tool_result = block.get("toolResult")
+    if isinstance(tool_result, dict):
+        return {
+            "type": "tool_call_response",
+            "id": tool_result.get("toolUseId"),
+            "response": _json_safe(tool_result.get("content")),
+        }
+
+    reasoning = block.get("reasoningContent")
+    if isinstance(reasoning, dict):
+        reasoning_text = reasoning.get("reasoningText")
+        if isinstance(reasoning_text, dict) and reasoning_text.get("text") is not None:
+            return {"type": "reasoning", "content": str(reasoning_text["text"])}
+
+    return {"type": "generic", "value": _json_safe(block)}
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, bytes):
+        return base64.b64encode(value).decode("ascii")
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    return str(value)
+
+
+def _set_json_attribute(span: Any, name: str, value: Any) -> None:
+    span.set_attribute(
+        name,
+        json.dumps(value, ensure_ascii=False, separators=(",", ":")),
+    )

--- a/promptlayer/promptlayer.py
+++ b/promptlayer/promptlayer.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import logging
 import os
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Dict, Iterable, List, Literal, Optional, Union
 
 import nest_asyncio
 from opentelemetry import context as otel_context, trace as otel_trace
@@ -13,7 +13,7 @@ from promptlayer.groups import AsyncGroupManager, GroupManager
 from promptlayer.promptlayer_base import PromptLayerBase
 from promptlayer.promptlayer_mixins import PromptLayerMixin
 from promptlayer.skills import AsyncSkillManager, SkillManager
-from promptlayer.span_exporter import _mark_openai_request_span
+from promptlayer.span_exporter import _mark_genai_request_span
 from promptlayer.streaming import astream_response, stream_response
 from promptlayer.tables import AsyncTableManager, TableManager
 from promptlayer.template_cache import PromptTemplateCache
@@ -39,6 +39,16 @@ from promptlayer.utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+_AUTO_INSTRUMENTED_RUN_PROVIDERS = frozenset(
+    {
+        "openai",
+        "openai.azure",
+        "anthropic",
+        "google",
+        "vertexai",
+    }
+)
 
 
 def get_base_url(base_url: Union[str, None]):
@@ -75,6 +85,7 @@ class PromptLayer(PromptLayerMixin):
         throw_on_error: bool = True,
         cache_ttl_seconds: int = 0,
         tracer_provider=None,
+        tracing_providers: Optional[Iterable[str]] = None,
     ):
         if api_key is None:
             api_key = os.environ.get("PROMPTLAYER_API_KEY")
@@ -98,6 +109,7 @@ class PromptLayer(PromptLayerMixin):
             self.throw_on_error,
             enable_tracing,
             tracer_provider,
+            tracing_providers,
         )
         self.evals = EvalManager(api_key, self.base_url, self.throw_on_error, self.tracer_provider)
         self.group = GroupManager(api_key, self.base_url, self.throw_on_error)
@@ -207,8 +219,8 @@ class PromptLayer(PromptLayerMixin):
         # streaming=False > Pydantic model instance
         # streaming=True > generator that yields ChatCompletionChunk pieces as they arrive
         try:
-            with _mark_openai_request_span(
-                enabled=llm_data["provider"] in {"openai", "openai.azure"},
+            with _mark_genai_request_span(
+                enabled=llm_data["provider"] in _AUTO_INSTRUMENTED_RUN_PROVIDERS,
                 request_log_span_id=pl_run_span_id,
             ):
                 response = llm_data["request_function"](
@@ -487,6 +499,7 @@ class AsyncPromptLayer(PromptLayerMixin):
         throw_on_error: bool = True,
         cache_ttl_seconds: int = 0,
         tracer_provider=None,
+        tracing_providers: Optional[Iterable[str]] = None,
     ):
         if api_key is None:
             api_key = os.environ.get("PROMPTLAYER_API_KEY")
@@ -510,6 +523,7 @@ class AsyncPromptLayer(PromptLayerMixin):
             self.throw_on_error,
             enable_tracing,
             tracer_provider,
+            tracing_providers,
         )
         self.evals = AsyncEvalManager(api_key, self.base_url, self.throw_on_error, self.tracer_provider)
         self.group = AsyncGroupManager(api_key, self.base_url, self.throw_on_error)
@@ -785,8 +799,8 @@ class AsyncPromptLayer(PromptLayerMixin):
         request_start_time = datetime.datetime.now(datetime.timezone.utc).timestamp()
 
         try:
-            with _mark_openai_request_span(
-                enabled=llm_data["provider"] in {"openai", "openai.azure"},
+            with _mark_genai_request_span(
+                enabled=llm_data["provider"] in _AUTO_INSTRUMENTED_RUN_PROVIDERS,
                 request_log_span_id=pl_run_span_id,
             ):
                 response = await llm_data["request_function"](

--- a/promptlayer/promptlayer.py
+++ b/promptlayer/promptlayer.py
@@ -2,10 +2,12 @@ import asyncio
 import json
 import logging
 import os
+from contextlib import contextmanager, nullcontext
 from typing import Any, Dict, Iterable, List, Literal, Optional, Union
 
 import nest_asyncio
 from opentelemetry import context as otel_context, trace as otel_trace
+from opentelemetry.trace import SpanKind, Status, StatusCode
 
 from promptlayer import exceptions as _exceptions
 from promptlayer.evaluations import AsyncEvalManager, EvalManager
@@ -13,7 +15,12 @@ from promptlayer.groups import AsyncGroupManager, GroupManager
 from promptlayer.promptlayer_base import PromptLayerBase
 from promptlayer.promptlayer_mixins import PromptLayerMixin
 from promptlayer.skills import AsyncSkillManager, SkillManager
-from promptlayer.span_exporter import _mark_genai_request_span
+from promptlayer.span_exporter import (
+    _defer_prompt_span_attribute_activation,
+    _mark_genai_request_span,
+    _prompt_span_attributes,
+    _scope_prompt_span_attributes,
+)
 from promptlayer.streaming import astream_response, stream_response
 from promptlayer.tables import AsyncTableManager, TableManager
 from promptlayer.template_cache import PromptTemplateCache
@@ -21,7 +28,6 @@ from promptlayer.templates import AsyncTemplateManager, TemplateManager
 from promptlayer.tracing_context import (
     awrap_stream_with_span,
     format_otel_span_id,
-    format_run_output,
     is_stream_result,
     wrap_stream_with_span,
 )
@@ -30,6 +36,7 @@ from promptlayer.track.error_tracking import categorize_error
 from promptlayer.types.prompt_template import PromptTemplate
 from promptlayer.utils import (
     RERAISE_ORIGINAL_EXCEPTION,
+    SDK_VERSION,
     _get_workflow_workflow_id_or_name,
     arun_workflow_request,
     atrack_request,
@@ -49,6 +56,105 @@ _AUTO_INSTRUMENTED_RUN_PROVIDERS = frozenset(
         "vertexai",
     }
 )
+
+_OTEL_SCALAR_TYPES = (bool, int, float, str)
+
+
+def _run_span_attributes(
+    *,
+    prompt_name: str,
+    prompt_version: Union[int, None],
+    prompt_release_label: Union[str, None],
+    metadata: Union[Dict[str, str], None],
+) -> Dict[str, Any]:
+    attributes: Dict[str, Any] = {
+        "node_type": "CODE_EXECUTION",
+        "prompt_name": prompt_name,
+        "promptlayer.prompt.name": prompt_name,
+        "promptlayer.telemetry.source": "promptlayer-python",
+        "promptlayer.telemetry.source_version": SDK_VERSION,
+    }
+    if prompt_version is not None:
+        attributes["promptlayer.prompt.version"] = str(prompt_version)
+    if prompt_release_label is not None:
+        attributes["promptlayer.prompt.label"] = prompt_release_label
+
+    for key, value in (metadata or {}).items():
+        if isinstance(key, str) and key and isinstance(value, _OTEL_SCALAR_TYPES):
+            attributes[f"promptlayer.metadata.{key}"] = value
+
+    return attributes
+
+
+def _prompt_fetch_attributes(
+    *,
+    prompt_name: str,
+    prompt_version: Union[int, None],
+    prompt_release_label: Union[str, None],
+) -> Dict[str, Any]:
+    attributes: Dict[str, Any] = {
+        "node_type": "PROMPT_TEMPLATE",
+        "prompt_name": prompt_name,
+        "promptlayer.prompt.name": prompt_name,
+        "promptlayer.prompt.requested.name": prompt_name,
+    }
+    if prompt_version is not None:
+        attributes["promptlayer.prompt.requested.version"] = str(prompt_version)
+    if prompt_release_label is not None:
+        attributes["promptlayer.prompt.requested.label"] = prompt_release_label
+    return attributes
+
+
+def _record_span_error(span, error: Exception) -> None:
+    try:
+        error_type = type(error).__qualname__
+        module = type(error).__module__
+        if module and module != "builtins":
+            error_type = f"{module}.{error_type}"
+
+        span.set_attribute("error.type", error_type)
+        span.record_exception(error)
+        span.set_status(Status(status_code=StatusCode.ERROR, description=f"{error_type}: {error}"))
+    except Exception:
+        logger.debug("PromptLayer could not record a tracing error", exc_info=True)
+
+
+def _set_span_attributes(span, attributes: Dict[str, str]) -> None:
+    try:
+        span.set_attributes(attributes)
+    except Exception:
+        logger.debug("PromptLayer could not set tracing attributes", exc_info=True)
+
+
+@contextmanager
+def _prompt_fetch_span(
+    tracer,
+    run_span,
+    *,
+    prompt_name: str,
+    prompt_version: Union[int, None],
+    prompt_release_label: Union[str, None],
+):
+    if tracer is None or run_span is None:
+        yield None
+        return
+
+    with tracer.start_as_current_span(
+        "Prompt template fetch",
+        kind=SpanKind.INTERNAL,
+        attributes=_prompt_fetch_attributes(
+            prompt_name=prompt_name,
+            prompt_version=prompt_version,
+            prompt_release_label=prompt_release_label,
+        ),
+        record_exception=False,
+        set_status_on_exception=False,
+    ) as span:
+        try:
+            yield span
+        except Exception as exc:
+            _record_span_error(span, exc)
+            raise
 
 
 def get_base_url(base_url: Union[str, None]):
@@ -181,6 +287,7 @@ class PromptLayer(PromptLayerMixin):
         group_id: Union[int, None] = None,
         stream: bool = False,
         pl_run_span_id: Union[str, None] = None,
+        pl_run_span=None,
         provider: Union[str, None] = None,
         model: Union[str, None] = None,
     ) -> Dict[str, Any]:
@@ -195,13 +302,32 @@ class PromptLayer(PromptLayerMixin):
             model=model,
             model_parameter_overrides=model_parameter_overrides,
         )
-        prompt_blueprint = self.templates.get(prompt_name, get_prompt_template_params)
-        if not prompt_blueprint:
-            raise _exceptions.PromptLayerNotFoundError(
-                f"Prompt template '{prompt_name}' not found.",
-                response=None,
-                body=None,
-            )
+        tracer = self.tracer
+        with _prompt_fetch_span(
+            tracer,
+            pl_run_span,
+            prompt_name=prompt_name,
+            prompt_version=prompt_version,
+            prompt_release_label=prompt_release_label,
+        ) as fetch_span:
+            fetch_context = _defer_prompt_span_attribute_activation() if fetch_span is not None else nullcontext()
+            with fetch_context:
+                prompt_blueprint = self.templates.get(prompt_name, get_prompt_template_params)
+            if not prompt_blueprint:
+                raise _exceptions.PromptLayerNotFoundError(
+                    f"Prompt template '{prompt_name}' not found.",
+                    response=None,
+                    body=None,
+                )
+            if fetch_span is not None:
+                resolved_prompt_attributes = _prompt_span_attributes(
+                    prompt_blueprint,
+                    prompt_name,
+                    label=prompt_release_label,
+                )
+                _set_span_attributes(fetch_span, resolved_prompt_attributes)
+        if fetch_span is not None:
+            _set_span_attributes(pl_run_span, resolved_prompt_attributes)
         prompt_blueprint_model = self._validate_and_extract_model_from_prompt_blueprint(
             prompt_blueprint=prompt_blueprint, prompt_name=prompt_name
         )
@@ -218,10 +344,15 @@ class PromptLayer(PromptLayerMixin):
         # response is just whatever the LLM call returns
         # streaming=False > Pydantic model instance
         # streaming=True > generator that yields ChatCompletionChunk pieces as they arrive
+        traced_run = tracer is not None and pl_run_span is not None
+        prompt_context = _scope_prompt_span_attributes(resolved_prompt_attributes) if traced_run else nullcontext()
         try:
-            with _mark_genai_request_span(
-                enabled=llm_data["provider"] in _AUTO_INSTRUMENTED_RUN_PROVIDERS,
-                request_log_span_id=pl_run_span_id,
+            with (
+                prompt_context,
+                _mark_genai_request_span(
+                    enabled=llm_data["provider"] in _AUTO_INSTRUMENTED_RUN_PROVIDERS,
+                    request_log_span_id=pl_run_span_id,
+                ),
             ):
                 response = llm_data["request_function"](
                     prompt_blueprint=llm_data["prompt_blueprint"],
@@ -340,28 +471,40 @@ class PromptLayer(PromptLayerMixin):
             "model": model,
         }
 
-        if self.tracer:
-            span = self.tracer.start_span("PromptLayer Run")
-            token = otel_context.attach(otel_trace.set_span_in_context(span))
-            try:
-                span.set_attribute("prompt_name", prompt_name)
-                span.set_attribute("function_input", str(_run_internal_kwargs))
-                span_ctx = span.get_span_context()
-                pl_run_span_id = format_otel_span_id(span_ctx.span_id) if span_ctx and span_ctx.is_valid else None
-                result = self._run_internal(**_run_internal_kwargs, pl_run_span_id=pl_run_span_id)
-                if is_stream_result(result):
-                    # Keep the span open until the stream is fully consumed.
-                    otel_context.detach(token)
-                    return wrap_stream_with_span(result, span)
-                span.set_attribute("function_output", format_run_output(result))
-                return result
-            except Exception as exc:
-                span.record_exception(exc)
-                raise
-            finally:
-                if not is_stream_result(locals().get("result")):
-                    span.end()
-                    otel_context.detach(token)
+        tracer = self.tracer
+        if tracer:
+            with _scope_prompt_span_attributes(None):
+                span = tracer.start_span(
+                    "PromptLayer Run",
+                    kind=SpanKind.INTERNAL,
+                    attributes=_run_span_attributes(
+                        prompt_name=prompt_name,
+                        prompt_version=prompt_version,
+                        prompt_release_label=prompt_release_label,
+                        metadata=metadata,
+                    ),
+                )
+                token = otel_context.attach(otel_trace.set_span_in_context(span))
+                result = None
+                try:
+                    span_ctx = span.get_span_context()
+                    pl_run_span_id = format_otel_span_id(span_ctx.span_id) if span_ctx and span_ctx.is_valid else None
+                    result = self._run_internal(
+                        **_run_internal_kwargs,
+                        pl_run_span_id=pl_run_span_id,
+                        pl_run_span=span,
+                    )
+                    if is_stream_result(result):
+                        otel_context.detach(token)
+                        return wrap_stream_with_span(result, span)
+                    return result
+                except Exception as exc:
+                    _record_span_error(span, exc)
+                    raise
+                finally:
+                    if not is_stream_result(result):
+                        otel_context.detach(token)
+                        span.end()
         else:
             return self._run_internal(**_run_internal_kwargs)
 
@@ -626,28 +769,40 @@ class AsyncPromptLayer(PromptLayerMixin):
             "model": model,
         }
 
-        if self.tracer:
-            span = self.tracer.start_span("PromptLayer Run")
-            token = otel_context.attach(otel_trace.set_span_in_context(span))
-            try:
-                span.set_attribute("prompt_name", prompt_name)
-                span.set_attribute("function_input", str(_run_internal_kwargs))
-                span_ctx = span.get_span_context()
-                pl_run_span_id = format_otel_span_id(span_ctx.span_id) if span_ctx and span_ctx.is_valid else None
-                result = await self._run_internal(**_run_internal_kwargs, pl_run_span_id=pl_run_span_id)
-                if is_stream_result(result):
-                    # Keep the span open until the stream is fully consumed.
-                    otel_context.detach(token)
-                    return awrap_stream_with_span(result, span)
-                span.set_attribute("function_output", format_run_output(result))
-                return result
-            except Exception as exc:
-                span.record_exception(exc)
-                raise
-            finally:
-                if not is_stream_result(locals().get("result")):
-                    span.end()
-                    otel_context.detach(token)
+        tracer = self.tracer
+        if tracer:
+            with _scope_prompt_span_attributes(None):
+                span = tracer.start_span(
+                    "PromptLayer Run",
+                    kind=SpanKind.INTERNAL,
+                    attributes=_run_span_attributes(
+                        prompt_name=prompt_name,
+                        prompt_version=prompt_version,
+                        prompt_release_label=prompt_release_label,
+                        metadata=metadata,
+                    ),
+                )
+                token = otel_context.attach(otel_trace.set_span_in_context(span))
+                result = None
+                try:
+                    span_ctx = span.get_span_context()
+                    pl_run_span_id = format_otel_span_id(span_ctx.span_id) if span_ctx and span_ctx.is_valid else None
+                    result = await self._run_internal(
+                        **_run_internal_kwargs,
+                        pl_run_span_id=pl_run_span_id,
+                        pl_run_span=span,
+                    )
+                    if is_stream_result(result):
+                        otel_context.detach(token)
+                        return awrap_stream_with_span(result, span)
+                    return result
+                except Exception as exc:
+                    _record_span_error(span, exc)
+                    raise
+                finally:
+                    if not is_stream_result(result):
+                        otel_context.detach(token)
+                        span.end()
         else:
             return await self._run_internal(**_run_internal_kwargs)
 
@@ -763,6 +918,7 @@ class AsyncPromptLayer(PromptLayerMixin):
         group_id: Union[int, None] = None,
         stream: bool = False,
         pl_run_span_id: Union[str, None] = None,
+        pl_run_span=None,
         provider: Union[str, None] = None,
         model: Union[str, None] = None,
     ) -> Dict[str, Any]:
@@ -777,13 +933,32 @@ class AsyncPromptLayer(PromptLayerMixin):
             model=model,
             model_parameter_overrides=model_parameter_overrides,
         )
-        prompt_blueprint = await self.templates.get(prompt_name, get_prompt_template_params)
-        if not prompt_blueprint:
-            raise _exceptions.PromptLayerNotFoundError(
-                f"Prompt template '{prompt_name}' not found.",
-                response=None,
-                body=None,
-            )
+        tracer = self.tracer
+        with _prompt_fetch_span(
+            tracer,
+            pl_run_span,
+            prompt_name=prompt_name,
+            prompt_version=prompt_version,
+            prompt_release_label=prompt_release_label,
+        ) as fetch_span:
+            fetch_context = _defer_prompt_span_attribute_activation() if fetch_span is not None else nullcontext()
+            with fetch_context:
+                prompt_blueprint = await self.templates.get(prompt_name, get_prompt_template_params)
+            if not prompt_blueprint:
+                raise _exceptions.PromptLayerNotFoundError(
+                    f"Prompt template '{prompt_name}' not found.",
+                    response=None,
+                    body=None,
+                )
+            if fetch_span is not None:
+                resolved_prompt_attributes = _prompt_span_attributes(
+                    prompt_blueprint,
+                    prompt_name,
+                    label=prompt_release_label,
+                )
+                _set_span_attributes(fetch_span, resolved_prompt_attributes)
+        if fetch_span is not None:
+            _set_span_attributes(pl_run_span, resolved_prompt_attributes)
         prompt_blueprint_model = self._validate_and_extract_model_from_prompt_blueprint(
             prompt_blueprint=prompt_blueprint, prompt_name=prompt_name
         )
@@ -798,10 +973,15 @@ class AsyncPromptLayer(PromptLayerMixin):
         # Capture start time before making the LLM request
         request_start_time = datetime.datetime.now(datetime.timezone.utc).timestamp()
 
+        traced_run = tracer is not None and pl_run_span is not None
+        prompt_context = _scope_prompt_span_attributes(resolved_prompt_attributes) if traced_run else nullcontext()
         try:
-            with _mark_genai_request_span(
-                enabled=llm_data["provider"] in _AUTO_INSTRUMENTED_RUN_PROVIDERS,
-                request_log_span_id=pl_run_span_id,
+            with (
+                prompt_context,
+                _mark_genai_request_span(
+                    enabled=llm_data["provider"] in _AUTO_INSTRUMENTED_RUN_PROVIDERS,
+                    request_log_span_id=pl_run_span_id,
+                ),
             ):
                 response = await llm_data["request_function"](
                     prompt_blueprint=llm_data["prompt_blueprint"],

--- a/promptlayer/promptlayer.py
+++ b/promptlayer/promptlayer.py
@@ -52,6 +52,7 @@ _AUTO_INSTRUMENTED_RUN_PROVIDERS = frozenset(
         "openai",
         "openai.azure",
         "anthropic",
+        "amazon.bedrock",
         "google",
         "vertexai",
     }

--- a/promptlayer/promptlayer_base.py
+++ b/promptlayer/promptlayer_base.py
@@ -3,8 +3,19 @@ import inspect
 import re
 
 from promptlayer import exceptions as _exceptions
+from promptlayer.span_exporter import _mark_genai_request_span
 from promptlayer.tracing_context import format_otel_span_id, resolve_tracer
 from promptlayer.utils import async_wrapper, promptlayer_api_handler
+
+_AUTO_INSTRUMENTED_PROVIDER_TYPES = frozenset(
+    {
+        "openai",
+        "openai.azure",
+        "anthropic",
+        "google",
+        "vertexai",
+    }
+)
 
 
 class PromptLayerBase(object):
@@ -93,7 +104,14 @@ class PromptLayerBase(object):
                     llm_request_span.set_attribute("function_output", str(result))
                     return result
 
-                function_response = function_object(*args, **kwargs)
+                managed_request_span = (
+                    object.__getattribute__(self, "_provider_type") in _AUTO_INSTRUMENTED_PROVIDER_TYPES
+                )
+                with _mark_genai_request_span(
+                    enabled=managed_request_span,
+                    request_log_span_id=llm_request_span_id,
+                ):
+                    function_response = function_object(*args, **kwargs)
 
                 if inspect.iscoroutinefunction(function_object) or inspect.iscoroutine(function_response):
                     return async_wrapper(
@@ -107,6 +125,7 @@ class PromptLayerBase(object):
                         tags,
                         llm_request_span_id=llm_request_span_id,
                         tracer=tracer,  # Pass the tracer to async_wrapper
+                        managed_request_span=managed_request_span,
                         *args,
                         **kwargs,
                     )

--- a/promptlayer/promptlayer_mixins.py
+++ b/promptlayer/promptlayer_mixins.py
@@ -2,7 +2,7 @@ import asyncio
 import datetime
 from copy import deepcopy
 from functools import wraps
-from typing import Any, Dict, Union
+from typing import Any, Dict, Iterable, Optional, Union
 
 from promptlayer.otlp import initialize_promptlayer_tracer
 from promptlayer.streaming import (
@@ -27,7 +27,7 @@ from promptlayer.streaming import (
     openai_stream_chat,
     openai_stream_completion,
 )
-from promptlayer.tracing import _configure_openai_sdk_instrumentation, configure_tracing
+from promptlayer.tracing import _configure_sdk_instrumentation, configure_tracing
 from promptlayer.tracing_context import resolve_tracer
 from promptlayer.utils import (
     aamazon_bedrock_request,
@@ -300,6 +300,7 @@ class PromptLayerMixin:
         throw_on_error: bool,
         enable_tracing: bool = False,
         tracer_provider=None,
+        tracing_providers: Optional[Iterable[str]] = None,
     ):
         del throw_on_error  # OTLP exporter does not use this flag.
         if not enable_tracing:
@@ -314,6 +315,7 @@ class PromptLayerMixin:
                 api_key=api_key,
                 base_url=base_url,
                 tracer_provider=tracer_provider,
+                providers=tracing_providers,
             )
             return provider, provider.get_tracer(__name__)
 
@@ -323,7 +325,7 @@ class PromptLayerMixin:
             enable_tracing=True,
         )
         if provider is not None:
-            _configure_openai_sdk_instrumentation(provider)
+            _configure_sdk_instrumentation(provider, providers=tracing_providers)
         return provider, tracer
 
     @staticmethod

--- a/promptlayer/span_exporter.py
+++ b/promptlayer/span_exporter.py
@@ -18,10 +18,12 @@ _BAGGAGE_KEYS = (
 )
 _LEGACY_OPENAI_INSTRUMENTATION_SCOPE = "opentelemetry.instrumentation.openai_v2"
 _GENAI_HANDLER_SCOPE = "opentelemetry.util.genai.handler"
+_BOTOCORE_BEDROCK_SCOPE = "opentelemetry.instrumentation.botocore.bedrock-runtime"
 _SUPPORTED_GENAI_PROVIDER_NAMES = frozenset(
     {
         "openai",
         "anthropic",
+        "aws.bedrock",
         "gemini",
         "vertex_ai",
         "gcp.gemini",
@@ -95,15 +97,22 @@ class GenAIPromptTemplateSpanProcessor(SpanProcessor):
         scope_name = getattr(instrumentation_scope, "name", "")
         attributes = getattr(span, "attributes", {}) or {}
         is_legacy_openai_span = scope_name == _LEGACY_OPENAI_INSTRUMENTATION_SCOPE
-        is_supported_genai_span = scope_name == _GENAI_HANDLER_SCOPE and (
-            attributes.get("gen_ai.provider.name") in _SUPPORTED_GENAI_PROVIDER_NAMES
+        is_botocore_bedrock_span = scope_name == _BOTOCORE_BEDROCK_SCOPE and (
+            attributes.get("gen_ai.system") == "aws.bedrock"
         )
-        if not is_legacy_openai_span and not is_supported_genai_span:
+        is_supported_genai_span = (
+            scope_name == _GENAI_HANDLER_SCOPE
+            and attributes.get("gen_ai.provider.name") in _SUPPORTED_GENAI_PROVIDER_NAMES
+        )
+        if not is_legacy_openai_span and not is_botocore_bedrock_span and not is_supported_genai_span:
             return
 
         if is_legacy_openai_span:
             span.set_attribute("gen_ai.provider.name", "openai")
         else:
+            if is_botocore_bedrock_span:
+                span.set_attribute("gen_ai.provider.name", "aws.bedrock")
+                attributes = getattr(span, "attributes", {}) or {}
             canonical_provider = _canonical_provider_type(attributes)
             if canonical_provider:
                 span.set_attribute(_PROMPTLAYER_PROVIDER_TYPE, canonical_provider)
@@ -147,6 +156,8 @@ def _canonical_provider_type(attributes: Dict[str, Any]) -> Optional[str]:
         return "google"
     if provider in {"vertex_ai", "gcp.vertex_ai"}:
         return "vertexai"
+    if provider == "aws.bedrock":
+        return "amazon.bedrock"
     return None
 
 
@@ -160,6 +171,12 @@ def _canonical_api_type(attributes: Dict[str, Any], canonical_provider: str) -> 
         return "chat-completions"
     if provider == "anthropic":
         return "messages"
+    if canonical_provider == "amazon.bedrock":
+        rpc_method = str(attributes.get("rpc.method") or "").strip().lower()
+        if rpc_method in {"converse", "conversestream"}:
+            return "converse"
+        if rpc_method in {"invokemodel", "invokemodelwithresponsestream"}:
+            return "invoke-model"
     if operation == "generate_content":
         return "generate-content"
     if operation == "interactions.create":

--- a/promptlayer/span_exporter.py
+++ b/promptlayer/span_exporter.py
@@ -36,6 +36,10 @@ _active_prompt_template: ContextVar[Optional[Dict[str, str]]] = ContextVar(
     "promptlayer_active_prompt_template",
     default=None,
 )
+_defer_prompt_span_attributes: ContextVar[bool] = ContextVar(
+    "promptlayer_defer_prompt_span_attributes",
+    default=False,
+)
 
 
 @dataclass(frozen=True)
@@ -106,6 +110,7 @@ class GenAIPromptTemplateSpanProcessor(SpanProcessor):
                 api_type = _canonical_api_type(attributes, canonical_provider)
                 if api_type:
                     span.set_attribute(_PROMPTLAYER_API_TYPE, api_type)
+        span.set_attribute("node_type", "LLM_CALL")
         prompt_attributes = _active_prompt_template.get()
         if prompt_attributes:
             span.set_attributes(prompt_attributes)
@@ -171,6 +176,83 @@ OpenAIPromptTemplateSpanProcessor = GenAIPromptTemplateSpanProcessor
 _mark_openai_request_span = _mark_genai_request_span
 
 
+def _prompt_span_attributes(
+    prompt_blueprint: Dict[str, Any],
+    prompt_name: str,
+    *,
+    label: Optional[str] = None,
+) -> Dict[str, str]:
+    entries: Dict[str, str] = {"promptlayer.prompt.name": prompt_name}
+
+    prompt_id = prompt_blueprint.get("id")
+    if prompt_id is not None:
+        entries["promptlayer.prompt.id"] = str(prompt_id)
+
+    version = prompt_blueprint.get("version")
+    if version is not None:
+        entries["promptlayer.prompt.version"] = str(version)
+
+    if label is not None:
+        entries["promptlayer.prompt.label"] = label
+
+    return entries
+
+
+@contextmanager
+def _defer_prompt_span_attribute_activation() -> Iterator[None]:
+    """Let a logical template-fetch span finish before activating prompt baggage."""
+
+    token = _defer_prompt_span_attributes.set(True)
+    try:
+        yield
+    finally:
+        _defer_prompt_span_attributes.reset(token)
+
+
+@contextmanager
+def _scope_prompt_span_attributes(
+    entries: Optional[Dict[str, str]],
+) -> Iterator[Optional[Dict[str, str]]]:
+    """Temporarily activate or clear prompt identity for child spans."""
+
+    active_prompt_token = None
+    baggage_token = None
+    try:
+        try:
+            active_prompt_token = _active_prompt_template.set(entries)
+            ctx = context.get_current()
+            for key in _BAGGAGE_KEYS:
+                if entries is not None and key in entries:
+                    ctx = baggage.set_baggage(key, entries[key], ctx)
+                else:
+                    ctx = baggage.remove_baggage(key, ctx)
+            baggage_token = context.attach(ctx)
+        except Exception:
+            logger.debug("PromptLayer could not scope prompt tracing attributes", exc_info=True)
+        yield entries
+    finally:
+        if baggage_token is not None:
+            try:
+                context.detach(baggage_token)
+            except Exception:
+                logger.debug("PromptLayer could not detach prompt tracing attributes", exc_info=True)
+        if active_prompt_token is not None:
+            _active_prompt_template.reset(active_prompt_token)
+
+
+def _set_prompt_fetch_cache_hit(cache_hit: bool) -> None:
+    """Annotate the active logical prompt fetch when SDK caching is in use."""
+
+    try:
+        if not _defer_prompt_span_attributes.get():
+            return
+        span = trace.get_current_span()
+        if span.is_recording():
+            span.set_attribute("promptlayer.prompt.cache_hit", cache_hit)
+    except Exception:
+        logger.debug("PromptLayer could not annotate prompt cache status", exc_info=True)
+
+
 def set_prompt_span_attributes(
     prompt_blueprint: Dict[str, Any],
     prompt_name: str,
@@ -186,18 +268,10 @@ def set_prompt_span_attributes(
     Also sets the attributes on the current span for direct visibility.
     """
     try:
-        entries: Dict[str, str] = {"promptlayer.prompt.name": prompt_name}
+        if _defer_prompt_span_attributes.get():
+            return
 
-        prompt_id = prompt_blueprint.get("id")
-        if prompt_id is not None:
-            entries["promptlayer.prompt.id"] = str(prompt_id)
-
-        version = prompt_blueprint.get("version")
-        if version is not None:
-            entries["promptlayer.prompt.version"] = str(version)
-
-        if label is not None:
-            entries["promptlayer.prompt.label"] = label
+        entries = _prompt_span_attributes(prompt_blueprint, prompt_name, label=label)
 
         _active_prompt_template.set(entries)
 

--- a/promptlayer/span_exporter.py
+++ b/promptlayer/span_exporter.py
@@ -1,3 +1,5 @@
+import logging
+import re
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -6,16 +8,30 @@ from typing import Any, Dict, Iterator, Optional
 from opentelemetry import baggage, context, trace
 from opentelemetry.sdk.trace import SpanProcessor
 
+logger = logging.getLogger(__name__)
+
 _BAGGAGE_KEYS = (
     "promptlayer.prompt.name",
     "promptlayer.prompt.id",
     "promptlayer.prompt.version",
     "promptlayer.prompt.label",
 )
-_OPENAI_INSTRUMENTATION_SCOPE = "opentelemetry.instrumentation.openai_v2"
+_LEGACY_OPENAI_INSTRUMENTATION_SCOPE = "opentelemetry.instrumentation.openai_v2"
 _GENAI_HANDLER_SCOPE = "opentelemetry.util.genai.handler"
+_SUPPORTED_GENAI_PROVIDER_NAMES = frozenset(
+    {
+        "openai",
+        "anthropic",
+        "gemini",
+        "vertex_ai",
+        "gcp.gemini",
+        "gcp.vertex_ai",
+    }
+)
 _PROMPTLAYER_REQUEST_LOG_MANAGED = "promptlayer.request_log.managed"
 _PROMPTLAYER_REQUEST_LOG_SPAN_ID = "promptlayer.request_log.span_id"
+_PROMPTLAYER_PROVIDER_TYPE = "promptlayer.provider.type"
+_PROMPTLAYER_API_TYPE = "promptlayer.api.type"
 _active_prompt_template: ContextVar[Optional[Dict[str, str]]] = ContextVar(
     "promptlayer_active_prompt_template",
     default=None,
@@ -23,52 +39,78 @@ _active_prompt_template: ContextVar[Optional[Dict[str, str]]] = ContextVar(
 
 
 @dataclass(frozen=True)
-class _OpenAIRequestSpanState:
+class _GenAIRequestSpanState:
     request_log_span_id: Optional[str] = None
 
 
-_OPENAI_REQUEST_SPAN_STATE_KEY = context.create_key("promptlayer.openai_request_span")
+_GENAI_REQUEST_SPAN_STATE_KEY = context.create_key("promptlayer.genai_request_span")
 
 
 @contextmanager
-def _mark_openai_request_span(
+def _mark_genai_request_span(
     *,
     enabled: bool,
     request_log_span_id: Optional[str],
 ) -> Iterator[None]:
-    """Link a native OpenAI span to the request log managed by PromptLayer.run."""
+    """Link a native GenAI span to the request log managed by PromptLayer.run."""
 
     if not enabled:
         yield
         return
 
-    state = _OpenAIRequestSpanState(request_log_span_id=request_log_span_id)
-    token = context.attach(context.set_value(_OPENAI_REQUEST_SPAN_STATE_KEY, state))
+    token = None
+    try:
+        state = _GenAIRequestSpanState(request_log_span_id=request_log_span_id)
+        token = context.attach(context.set_value(_GENAI_REQUEST_SPAN_STATE_KEY, state))
+    except Exception:
+        logger.debug("PromptLayer could not attach GenAI request context", exc_info=True)
     try:
         yield
     finally:
-        context.detach(token)
+        if token is not None:
+            try:
+                context.detach(token)
+            except Exception:
+                logger.debug("PromptLayer could not detach GenAI request context", exc_info=True)
 
 
-class OpenAIPromptTemplateSpanProcessor(SpanProcessor):
-    """Enrich native OpenAI spans and correlate PromptLayer-managed requests."""
+class GenAIPromptTemplateSpanProcessor(SpanProcessor):
+    """Enrich supported GenAI spans and correlate PromptLayer-managed requests."""
 
     def on_start(self, span: Any, parent_context: Any = None) -> None:
+        try:
+            self._on_start(span, parent_context)
+        except Exception:
+            # Span processors run inline with provider SDK calls. PromptLayer
+            # enrichment must never affect the underlying request.
+            logger.debug("PromptLayer could not enrich a GenAI span", exc_info=True)
+
+    @staticmethod
+    def _on_start(span: Any, parent_context: Any = None) -> None:
         instrumentation_scope = getattr(span, "instrumentation_scope", None)
         scope_name = getattr(instrumentation_scope, "name", "")
         attributes = getattr(span, "attributes", {}) or {}
-        is_openai_span = scope_name == _OPENAI_INSTRUMENTATION_SCOPE or (
-            scope_name == _GENAI_HANDLER_SCOPE and attributes.get("gen_ai.provider.name") == "openai"
+        is_legacy_openai_span = scope_name == _LEGACY_OPENAI_INSTRUMENTATION_SCOPE
+        is_supported_genai_span = scope_name == _GENAI_HANDLER_SCOPE and (
+            attributes.get("gen_ai.provider.name") in _SUPPORTED_GENAI_PROVIDER_NAMES
         )
-        if not is_openai_span:
+        if not is_legacy_openai_span and not is_supported_genai_span:
             return
 
-        span.set_attribute("gen_ai.provider.name", "openai")
+        if is_legacy_openai_span:
+            span.set_attribute("gen_ai.provider.name", "openai")
+        else:
+            canonical_provider = _canonical_provider_type(attributes)
+            if canonical_provider:
+                span.set_attribute(_PROMPTLAYER_PROVIDER_TYPE, canonical_provider)
+                api_type = _canonical_api_type(attributes, canonical_provider)
+                if api_type:
+                    span.set_attribute(_PROMPTLAYER_API_TYPE, api_type)
         prompt_attributes = _active_prompt_template.get()
         if prompt_attributes:
             span.set_attributes(prompt_attributes)
 
-        request_span_state = context.get_value(_OPENAI_REQUEST_SPAN_STATE_KEY, parent_context)
+        request_span_state = context.get_value(_GENAI_REQUEST_SPAN_STATE_KEY, parent_context)
         if request_span_state is None:
             return
 
@@ -81,6 +123,54 @@ class OpenAIPromptTemplateSpanProcessor(SpanProcessor):
             )
 
 
+def _canonical_provider_type(attributes: Dict[str, Any]) -> Optional[str]:
+    provider = str(attributes.get("gen_ai.provider.name") or "").strip().lower()
+    server_address = str(attributes.get("server.address") or "").strip().lower()
+
+    if provider == "openai":
+        if server_address.endswith(".openai.azure.com") or server_address.endswith(".cognitiveservices.azure.com"):
+            return "openai.azure"
+        return "openai"
+    if provider == "anthropic":
+        if re.fullmatch(
+            r"(?:[a-z0-9]+(?:-[a-z0-9]+)*-)?aiplatform\.googleapis\.com",
+            server_address,
+        ):
+            return "vertexai"
+        return "anthropic"
+    if provider in {"gemini", "gcp.gemini"}:
+        return "google"
+    if provider in {"vertex_ai", "gcp.vertex_ai"}:
+        return "vertexai"
+    return None
+
+
+def _canonical_api_type(attributes: Dict[str, Any], canonical_provider: str) -> Optional[str]:
+    operation = str(attributes.get("gen_ai.operation.name") or "").strip().lower()
+    provider = str(attributes.get("gen_ai.provider.name") or "").strip().lower()
+
+    if operation == "embeddings":
+        return "embeddings"
+    if canonical_provider in {"openai", "openai.azure"}:
+        return "chat-completions"
+    if provider == "anthropic":
+        return "messages"
+    if operation == "generate_content":
+        return "generate-content"
+    if operation == "interactions.create":
+        return "interactions"
+    return None
+
+
+# Preserve the existing import while the processor now supports all configured
+# GenAI providers.
+OpenAIPromptTemplateSpanProcessor = GenAIPromptTemplateSpanProcessor
+
+# Preserve the internal context manager for callers that have not migrated to
+# the provider-neutral name.
+_mark_openai_request_span = _mark_genai_request_span
+
+
 def set_prompt_span_attributes(
     prompt_blueprint: Dict[str, Any],
     prompt_name: str,
@@ -91,34 +181,37 @@ def set_prompt_span_attributes(
 
     When used with a ``BaggageSpanProcessor``, these baggage entries are
     automatically copied as attributes onto every child span — including
-    auto-instrumented LLM spans (e.g. from ``OpenAIInstrumentor``).
+    auto-instrumented GenAI spans.
 
     Also sets the attributes on the current span for direct visibility.
     """
-    entries: Dict[str, str] = {"promptlayer.prompt.name": prompt_name}
+    try:
+        entries: Dict[str, str] = {"promptlayer.prompt.name": prompt_name}
 
-    prompt_id = prompt_blueprint.get("id")
-    if prompt_id is not None:
-        entries["promptlayer.prompt.id"] = str(prompt_id)
+        prompt_id = prompt_blueprint.get("id")
+        if prompt_id is not None:
+            entries["promptlayer.prompt.id"] = str(prompt_id)
 
-    version = prompt_blueprint.get("version")
-    if version is not None:
-        entries["promptlayer.prompt.version"] = str(version)
+        version = prompt_blueprint.get("version")
+        if version is not None:
+            entries["promptlayer.prompt.version"] = str(version)
 
-    if label is not None:
-        entries["promptlayer.prompt.label"] = label
+        if label is not None:
+            entries["promptlayer.prompt.label"] = label
 
-    _active_prompt_template.set(entries)
+        _active_prompt_template.set(entries)
 
-    span = trace.get_current_span()
-    if span.is_recording():
-        for key, value in entries.items():
-            span.set_attribute(key, value)
+        span = trace.get_current_span()
+        if span.is_recording():
+            for key, value in entries.items():
+                span.set_attribute(key, value)
 
-    ctx = context.get_current()
-    for key in _BAGGAGE_KEYS:
-        if key in entries:
-            ctx = baggage.set_baggage(key, entries[key], ctx)
-        else:
-            ctx = baggage.remove_baggage(key, ctx)
-    context.attach(ctx)
+        ctx = context.get_current()
+        for key in _BAGGAGE_KEYS:
+            if key in entries:
+                ctx = baggage.set_baggage(key, entries[key], ctx)
+            else:
+                ctx = baggage.remove_baggage(key, ctx)
+        context.attach(ctx)
+    except Exception:
+        logger.debug("PromptLayer could not attach prompt tracing attributes", exc_info=True)

--- a/promptlayer/templates.py
+++ b/promptlayer/templates.py
@@ -2,7 +2,7 @@ import logging
 from typing import Optional, Union
 
 from promptlayer import exceptions as _exceptions
-from promptlayer.span_exporter import set_prompt_span_attributes
+from promptlayer.span_exporter import _set_prompt_fetch_cache_hit, set_prompt_span_attributes
 from promptlayer.template_cache import (
     PromptTemplateCache,
     is_locally_renderable,
@@ -64,16 +64,19 @@ class TemplateManager:
         label = _extract_label(params)
 
         if self._cache.is_non_renderable(cache_key):
+            _set_prompt_fetch_cache_hit(False)
             return self._fetch_normal(prompt_name, params)
 
         cached, is_fresh = self._cache.get(cache_key)
 
         if cached is not None and is_fresh:
+            _set_prompt_fetch_cache_hit(True)
             result = render_response(cached, input_variables)
             set_prompt_span_attributes(result, prompt_name, label=label)
             return result
 
         stale = cached
+        _set_prompt_fetch_cache_hit(False)
 
         cache_params = make_cache_params(params)
         try:
@@ -81,6 +84,7 @@ class TemplateManager:
         except _TRANSIENT_ERRORS:
             if stale is not None:
                 logger.debug("Transient API error, serving stale cache for '%s'", prompt_name)
+                _set_prompt_fetch_cache_hit(True)
                 result = render_response(stale, input_variables)
                 set_prompt_span_attributes(result, prompt_name, label=label)
                 return result
@@ -154,16 +158,19 @@ class AsyncTemplateManager:
         label = _extract_label(params)
 
         if self._cache.is_non_renderable(cache_key):
+            _set_prompt_fetch_cache_hit(False)
             return await self._afetch_normal(prompt_name, params)
 
         cached, is_fresh = self._cache.get(cache_key)
 
         if cached is not None and is_fresh:
+            _set_prompt_fetch_cache_hit(True)
             result = render_response(cached, input_variables)
             set_prompt_span_attributes(result, prompt_name, label=label)
             return result
 
         stale = cached
+        _set_prompt_fetch_cache_hit(False)
 
         cache_params = make_cache_params(params)
         try:
@@ -171,6 +178,7 @@ class AsyncTemplateManager:
         except _TRANSIENT_ERRORS:
             if stale is not None:
                 logger.debug("Transient API error, serving stale cache for '%s'", prompt_name)
+                _set_prompt_fetch_cache_hit(True)
                 result = render_response(stale, input_variables)
                 set_prompt_span_attributes(result, prompt_name, label=label)
                 return result

--- a/promptlayer/tracing.py
+++ b/promptlayer/tracing.py
@@ -6,7 +6,9 @@ import logging
 import os
 import threading
 import weakref
-from typing import Any, Iterable, Optional, Tuple
+from dataclasses import dataclass
+from functools import wraps
+from typing import Any, Dict, Iterable, Optional, Tuple
 
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
@@ -15,22 +17,55 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.semconv.resource import ResourceAttributes
 
-from promptlayer.span_exporter import OpenAIPromptTemplateSpanProcessor
+from promptlayer.span_exporter import (
+    _PROMPTLAYER_API_TYPE,
+    GenAIPromptTemplateSpanProcessor,
+)
 from promptlayer.utils import _PROMPTLAYER_USER_AGENT, SDK_VERSION
 
 logger = logging.getLogger(__name__)
 
-NATIVE_OTEL_PROVIDERS = ("openai",)
+
+@dataclass(frozen=True)
+class _ProviderInstrumentation:
+    sdk_module: str
+    instrumentation_module: str
+    instrumentor_class: str
+    display_name: str
+
+
+_PROVIDER_INSTRUMENTATIONS = {
+    "openai": _ProviderInstrumentation(
+        sdk_module="openai",
+        instrumentation_module="opentelemetry.instrumentation.genai.openai",
+        instrumentor_class="OpenAIInstrumentor",
+        display_name="OpenAI",
+    ),
+    "anthropic": _ProviderInstrumentation(
+        sdk_module="anthropic",
+        instrumentation_module="opentelemetry.instrumentation.genai.anthropic",
+        instrumentor_class="AnthropicInstrumentor",
+        display_name="Anthropic",
+    ),
+    "google": _ProviderInstrumentation(
+        sdk_module="google.genai",
+        instrumentation_module="opentelemetry.instrumentation.google_genai",
+        instrumentor_class="GoogleGenAiSdkInstrumentor",
+        display_name="Google GenAI",
+    ),
+}
+
+NATIVE_OTEL_PROVIDERS = tuple(_PROVIDER_INSTRUMENTATIONS)
 
 _PROVIDER_ALIASES = {
     "openai.azure": "openai",
 }
 _exporter_settings: weakref.WeakKeyDictionary[Any, Tuple[str, str]] = weakref.WeakKeyDictionary()
-_prompt_processor_providers: weakref.WeakKeyDictionary[Any, OpenAIPromptTemplateSpanProcessor] = (
+_prompt_processor_providers: weakref.WeakKeyDictionary[Any, GenAIPromptTemplateSpanProcessor] = (
     weakref.WeakKeyDictionary()
 )
 _configuration_lock = threading.RLock()
-_openai_instrumented_provider: Optional[Any] = None
+_instrumented_provider_owners: Dict[str, Any] = {}
 
 
 def instrument_openai(
@@ -47,18 +82,16 @@ def instrument_openai(
     advanced OpenTelemetry configuration.
     """
 
-    global _openai_instrumented_provider
-
     with _configuration_lock:
         resolved_api_key = _resolve_api_key(api_key)
-        instrumentor = _load_openai_instrumentor(explicit=True)
+        instrumentor = _load_provider_instrumentor("openai", explicit=True)
         provider = tracer_provider if tracer_provider is not None else _get_or_create_tracer_provider()
         _validate_tracer_provider(provider)
         if (
             instrumentor is not None
             and instrumentor.is_instrumented_by_opentelemetry
-            and _openai_instrumented_provider is not None
-            and _openai_instrumented_provider is not provider
+            and _instrumented_provider_owners.get("openai") is not None
+            and _instrumented_provider_owners["openai"] is not provider
         ):
             raise RuntimeError(
                 "The OpenAI SDK is already instrumented with a different tracer provider. "
@@ -75,9 +108,9 @@ def instrument_openai(
         if (
             instrumentor is not None
             and instrumentor.is_instrumented_by_opentelemetry
-            and _openai_instrumented_provider is None
+            and _instrumented_provider_owners.get("openai") is None
         ):
-            _openai_instrumented_provider = provider
+            _instrumented_provider_owners["openai"] = provider
         return configured_provider
 
 
@@ -89,20 +122,32 @@ def configure_tracing(
     tracer_provider: Optional[Any] = None,
     providers: Optional[Iterable[str]] = None,
 ) -> Any:
-    """Export spans to PromptLayer and auto-instrument the OpenAI SDK."""
+    """Export spans to PromptLayer and auto-instrument selected GenAI SDKs."""
 
-    resolved_api_key = _resolve_api_key(api_key)
+    with _configuration_lock:
+        resolved_api_key = _resolve_api_key(api_key)
+        selected_providers = _normalize_providers(providers)
+        explicit_instrumentors = {}
+        if providers is not None:
+            explicit_instrumentors = {
+                provider_name: _load_provider_instrumentor(provider_name, explicit=True)
+                for provider_name in selected_providers
+            }
 
-    provider = tracer_provider if tracer_provider is not None else _get_or_create_tracer_provider()
-    _validate_tracer_provider(provider)
-    selected_providers = _normalize_providers(providers)
-    if "openai" in selected_providers:
-        _add_openai_prompt_processor(provider)
-    _add_exporter(provider, resolved_api_key, _resolve_endpoint(endpoint, base_url))
-    _enable_latest_genai_semantic_conventions()
-    if "openai" in selected_providers:
-        _instrument_openai(provider, explicit=providers is not None)
-    return provider
+        provider = tracer_provider if tracer_provider is not None else _get_or_create_tracer_provider()
+        _validate_tracer_provider(provider)
+        if selected_providers:
+            _add_genai_prompt_processor(provider)
+        _add_exporter(provider, resolved_api_key, _resolve_endpoint(endpoint, base_url))
+        _enable_latest_genai_semantic_conventions()
+        for provider_name in selected_providers:
+            _instrument_provider(
+                provider_name,
+                provider,
+                explicit=providers is not None,
+                instrumentor=explicit_instrumentors.get(provider_name),
+            )
+        return provider
 
 
 def _resolve_api_key(api_key: Optional[str]) -> str:
@@ -141,11 +186,11 @@ def _resolve_endpoint(endpoint: Optional[str], base_url: Optional[str]) -> str:
     return f"{root}/v1/traces"
 
 
-def _add_openai_prompt_processor(provider: Any) -> None:
+def _add_genai_prompt_processor(provider: Any) -> None:
     if provider in _prompt_processor_providers:
         return
 
-    processor = OpenAIPromptTemplateSpanProcessor()
+    processor = GenAIPromptTemplateSpanProcessor()
     provider.add_span_processor(processor)
     _prompt_processor_providers[provider] = processor
 
@@ -170,61 +215,127 @@ def _add_exporter(provider: Any, api_key: str, endpoint: str) -> None:
     _exporter_settings[provider] = settings
 
 
-def _instrument_openai(tracer_provider: Any, *, explicit: bool) -> None:
-    global _openai_instrumented_provider
-
-    instrumentor = _load_openai_instrumentor(explicit=explicit)
+def _instrument_provider(
+    provider_name: str,
+    tracer_provider: Any,
+    *,
+    explicit: bool,
+    instrumentor: Optional[Any] = None,
+) -> None:
+    instrumentor = instrumentor or _load_provider_instrumentor(provider_name, explicit=explicit)
     if instrumentor is None:
         return
 
+    if provider_name == "openai":
+        _configure_openai_response_api_enrichment()
+
+    config = _PROVIDER_INSTRUMENTATIONS[provider_name]
     if not instrumentor.is_instrumented_by_opentelemetry:
-        instrumentor.instrument(tracer_provider=tracer_provider)
+        try:
+            instrumentor.instrument(tracer_provider=tracer_provider)
+        except Exception:
+            if explicit:
+                raise
+            logger.warning(
+                "PromptLayer could not enable %s auto-instrumentation; provider calls will continue uninstrumented",
+                config.display_name,
+                exc_info=True,
+            )
+            return
         if instrumentor.is_instrumented_by_opentelemetry:
-            _openai_instrumented_provider = tracer_provider
+            _instrumented_provider_owners[provider_name] = tracer_provider
         elif explicit:
             raise RuntimeError(
-                "OpenTelemetry OpenAI instrumentation could not be enabled. "
-                "Check that the installed OpenAI SDK version is supported."
+                f"OpenTelemetry {config.display_name} instrumentation could not be enabled. "
+                f"Check that the installed {config.display_name} SDK version is supported."
             )
-    elif _openai_instrumented_provider is not None and _openai_instrumented_provider is not tracer_provider:
+    elif (
+        _instrumented_provider_owners.get(provider_name) is not None
+        and _instrumented_provider_owners[provider_name] is not tracer_provider
+    ):
         logger.warning(
-            "The OpenAI SDK is already instrumented with a different tracer provider; "
-            "the existing provider remains active"
+            "%s SDK is already instrumented with a different tracer provider; the existing provider remains active",
+            config.display_name,
         )
 
 
-def _load_openai_instrumentor(*, explicit: bool) -> Optional[Any]:
-    sdk_installed = _module_available("openai")
+def _configure_openai_response_api_enrichment() -> None:
+    """Tag official OpenAI Responses spans without changing their OTel operation."""
+
+    try:
+        patch_responses = importlib.import_module("opentelemetry.instrumentation.genai.openai.patch_responses")
+        current = getattr(patch_responses, "apply_request_attributes", None)
+        if current is None or getattr(current, "_promptlayer_enriched", False):
+            return
+
+        @wraps(current)
+        def apply_request_attributes(invocation, *args, **kwargs):
+            try:
+                current(invocation, *args, **kwargs)
+                invocation.attributes[_PROMPTLAYER_API_TYPE] = "responses"
+            except Exception:
+                logger.debug("PromptLayer could not classify an OpenAI Responses span", exc_info=True)
+
+        apply_request_attributes._promptlayer_enriched = True
+        patch_responses.apply_request_attributes = apply_request_attributes
+    except Exception:
+        logger.debug("OpenAI Responses enrichment is unavailable", exc_info=True)
+
+
+def _load_provider_instrumentor(provider_name: str, *, explicit: bool) -> Optional[Any]:
+    config = _PROVIDER_INSTRUMENTATIONS[provider_name]
+    sdk_installed = _module_available(config.sdk_module)
     instrumentor_class = None
     if sdk_installed:
         try:
-            module = importlib.import_module("opentelemetry.instrumentation.openai_v2")
-            instrumentor_class = getattr(module, "OpenAIInstrumentor")
+            module = importlib.import_module(config.instrumentation_module)
+            instrumentor_class = getattr(module, config.instrumentor_class)
         except (AttributeError, ImportError):
             pass
 
     if instrumentor_class is None:
         if explicit:
             raise ImportError(
-                "OpenTelemetry OpenAI instrumentation is unavailable. "
-                'Install the "promptlayer[otel-genai-instrumentation]" extra and the OpenAI SDK.'
+                f"OpenTelemetry {config.display_name} instrumentation is unavailable. "
+                f'Install the "promptlayer[otel-genai-instrumentation]" extra and the {config.display_name} SDK.'
             )
         if sdk_installed:
             logger.warning(
-                "OpenTelemetry instrumentation is unavailable for OpenAI; "
-                "install promptlayer[otel-genai-instrumentation]"
+                "OpenTelemetry instrumentation is unavailable for %s; install promptlayer[otel-genai-instrumentation]",
+                config.display_name,
             )
         return None
     return instrumentor_class()
 
 
-def _configure_openai_sdk_instrumentation(tracer_provider: Any) -> None:
-    """Add OpenAI auto-instrumentation to an already configured provider."""
+def _load_openai_instrumentor(*, explicit: bool) -> Optional[Any]:
+    """Backward-compatible internal wrapper for the OpenAI loader."""
+
+    return _load_provider_instrumentor("openai", explicit=explicit)
+
+
+def _configure_sdk_instrumentation(
+    tracer_provider: Any,
+    providers: Optional[Iterable[str]] = None,
+) -> None:
+    """Add supported GenAI SDK auto-instrumentation to a configured provider."""
 
     _validate_tracer_provider(tracer_provider)
-    _add_openai_prompt_processor(tracer_provider)
+    selected_providers = _normalize_providers(providers)
+    if selected_providers:
+        _add_genai_prompt_processor(tracer_provider)
     _enable_latest_genai_semantic_conventions()
-    _instrument_openai(tracer_provider, explicit=False)
+    for provider_name in selected_providers:
+        _instrument_provider(provider_name, tracer_provider, explicit=False)
+
+
+def _configure_openai_sdk_instrumentation(tracer_provider: Any) -> None:
+    """Backward-compatible internal helper for OpenAI-only instrumentation."""
+
+    _validate_tracer_provider(tracer_provider)
+    _add_genai_prompt_processor(tracer_provider)
+    _enable_latest_genai_semantic_conventions()
+    _instrument_provider("openai", tracer_provider, explicit=False)
 
 
 def _normalize_providers(providers: Optional[Iterable[str]]) -> Tuple[str, ...]:
@@ -234,7 +345,7 @@ def _normalize_providers(providers: Optional[Iterable[str]]) -> Tuple[str, ...]:
     normalized = []
     for provider in providers:
         provider_name = _PROVIDER_ALIASES.get(provider, provider)
-        if provider_name != "openai":
+        if provider_name not in _PROVIDER_INSTRUMENTATIONS:
             raise ValueError(f"Unknown tracing provider: {provider}")
         if provider_name not in normalized:
             normalized.append(provider_name)

--- a/promptlayer/tracing.py
+++ b/promptlayer/tracing.py
@@ -17,6 +17,7 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.semconv.resource import ResourceAttributes
 
+from promptlayer.integrations.bedrock import bedrock_request_hook, bedrock_response_hook
 from promptlayer.span_exporter import (
     _PROMPTLAYER_API_TYPE,
     GenAIPromptTemplateSpanProcessor,
@@ -53,12 +54,20 @@ _PROVIDER_INSTRUMENTATIONS = {
         instrumentor_class="GoogleGenAiSdkInstrumentor",
         display_name="Google GenAI",
     ),
+    "bedrock": _ProviderInstrumentation(
+        sdk_module="boto3",
+        instrumentation_module="opentelemetry.instrumentation.botocore",
+        instrumentor_class="BotocoreInstrumentor",
+        display_name="AWS Bedrock",
+    ),
 }
 
 NATIVE_OTEL_PROVIDERS = tuple(_PROVIDER_INSTRUMENTATIONS)
 
 _PROVIDER_ALIASES = {
     "openai.azure": "openai",
+    "amazon.bedrock": "bedrock",
+    "aws.bedrock": "bedrock",
 }
 _exporter_settings: weakref.WeakKeyDictionary[Any, Tuple[str, str]] = weakref.WeakKeyDictionary()
 _prompt_processor_providers: weakref.WeakKeyDictionary[Any, GenAIPromptTemplateSpanProcessor] = (
@@ -232,7 +241,13 @@ def _instrument_provider(
     config = _PROVIDER_INSTRUMENTATIONS[provider_name]
     if not instrumentor.is_instrumented_by_opentelemetry:
         try:
-            instrumentor.instrument(tracer_provider=tracer_provider)
+            instrument_kwargs = {"tracer_provider": tracer_provider}
+            if provider_name == "bedrock":
+                instrument_kwargs.update(
+                    request_hook=bedrock_request_hook,
+                    response_hook=bedrock_response_hook,
+                )
+            instrumentor.instrument(**instrument_kwargs)
         except Exception:
             if explicit:
                 raise

--- a/promptlayer/tracing_context.py
+++ b/promptlayer/tracing_context.py
@@ -53,13 +53,9 @@ def format_run_output(result: Any) -> str:
 
 
 def wrap_stream_with_span(stream: Generator, span) -> Generator:
-    final_chunk = None
     try:
         for chunk in stream:
-            final_chunk = chunk
             yield chunk
-        if final_chunk is not None:
-            span.set_attribute("function_output", format_run_output(final_chunk))
     except Exception as exc:
         span.record_exception(exc)
         raise
@@ -68,13 +64,9 @@ def wrap_stream_with_span(stream: Generator, span) -> Generator:
 
 
 async def awrap_stream_with_span(stream: AsyncGenerator, span) -> AsyncGenerator:
-    final_chunk = None
     try:
         async for chunk in stream:
-            final_chunk = chunk
             yield chunk
-        if final_chunk is not None:
-            span.set_attribute("function_output", format_run_output(final_chunk))
     except Exception as exc:
         span.record_exception(exc)
         raise

--- a/promptlayer/utils.py
+++ b/promptlayer/utils.py
@@ -37,6 +37,7 @@ from tenacity import (
 )
 
 from promptlayer import exceptions as _exceptions
+from promptlayer.span_exporter import _mark_genai_request_span
 from promptlayer.types import RequestLog
 from promptlayer.types.prompt_template import (
     GetPromptTemplate,
@@ -63,6 +64,14 @@ def _get_sdk_version() -> str:
 SDK_VERSION = _get_sdk_version()
 _PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
 _PROMPTLAYER_USER_AGENT = f"promptlayer-python/{SDK_VERSION} (python {_PYTHON_VERSION})"
+# Providers whose PromptLayer wrappers can return an instrumented stream manager.
+_GENERATOR_PROXY_PROVIDER_TYPES = frozenset(
+    {
+        "openai",
+        "openai.azure",
+        "anthropic",
+    }
+)
 
 WORKFLOW_RUN_URL_TEMPLATE = "{base_url}/workflows/{workflow_id}/run"
 WORKFLOW_RUN_CHANNEL_NAME_TEMPLATE = "workflows:{workflow_id}:run:{channel_name_suffix}"
@@ -473,9 +482,16 @@ def promptlayer_api_handler(
             "AsyncMessageStreamManager",
             "MessageStreamManager",
             "ChatStreamWrapper",
+            "AsyncChatStreamWrapper",
             "LegacyChatStreamWrapper",
             "ResponseStreamWrapper",
             "AsyncResponseStreamWrapper",
+            "ResponseStreamManagerWrapper",
+            "AsyncResponseStreamManagerWrapper",
+            "MessagesStreamWrapper",
+            "AsyncMessagesStreamWrapper",
+            "MessagesStreamManagerWrapper",
+            "AsyncMessagesStreamManagerWrapper",
         ]
     ):
         return GeneratorProxy(
@@ -1129,30 +1145,57 @@ class GeneratorProxy:
 
     async def __aenter__(self):
         api_request_arguments = self.api_request_arugments
-        if hasattr(self.generator, "_AsyncMessageStreamManager__api_request"):
-            return GeneratorProxy(
-                await self.generator._AsyncMessageStreamManager__api_request,
-                api_request_arguments,
-                self.api_key,
-                self.base_url,
-            )
+        with _mark_genai_request_span(
+            enabled=self._should_propagate_managed_span_context(),
+            request_log_span_id=api_request_arguments.get("llm_request_span_id"),
+        ):
+            enter = getattr(self.generator, "__aenter__", None)
+            if callable(enter):
+                stream = await enter()
+            elif hasattr(self.generator, "_AsyncMessageStreamManager__api_request"):
+                stream = await self.generator._AsyncMessageStreamManager__api_request
+            else:
+                return self
+
+        return GeneratorProxy(
+            stream,
+            api_request_arguments,
+            self.api_key,
+            self.base_url,
+        )
 
     def __enter__(self):
         api_request_arguments = self.api_request_arugments
-        if hasattr(self.generator, "_MessageStreamManager__api_request"):
-            stream = self.generator.__enter__()
-            return GeneratorProxy(
-                stream,
-                api_request_arguments,
-                self.api_key,
-                self.base_url,
-            )
+        with _mark_genai_request_span(
+            enabled=self._should_propagate_managed_span_context(),
+            request_log_span_id=api_request_arguments.get("llm_request_span_id"),
+        ):
+            enter = getattr(self.generator, "__enter__", None)
+            if callable(enter):
+                stream = self.generator.__enter__()
+            elif hasattr(self.generator, "_MessageStreamManager__api_request"):
+                stream = self.generator._MessageStreamManager__api_request
+            else:
+                return self
+
+        return GeneratorProxy(
+            stream,
+            api_request_arguments,
+            self.api_key,
+            self.base_url,
+        )
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        pass
+        exit_method = getattr(self.generator, "__exit__", None)
+        if callable(exit_method):
+            return exit_method(exc_type, exc_val, exc_tb)
+        return None
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        pass
+        exit_method = getattr(self.generator, "__aexit__", None)
+        if callable(exit_method):
+            return await exit_method(exc_type, exc_val, exc_tb)
+        return None
 
     async def __anext__(self):
         result = await self.generator.__anext__()
@@ -1163,7 +1206,7 @@ class GeneratorProxy:
         return self._abstracted_next(result)
 
     def __getattr__(self, name):
-        if name == "text_stream":  # anthropic async stream
+        if name == "text_stream":
             return GeneratorProxy(
                 self.generator.text_stream,
                 self.api_request_arugments,
@@ -1181,13 +1224,13 @@ class GeneratorProxy:
             if hasattr(result, "stop_reason"):
                 end_anthropic = result.stop_reason
             elif hasattr(result, "message"):
-                end_anthropic = result.message.stop_reason
+                end_anthropic = getattr(result.message, "stop_reason", None)
             elif hasattr(result, "type") and result.type == "message_stop":
                 end_anthropic = True
 
-        end_openai = provider_type == "openai" and (
-            result.choices[0].finish_reason == "stop" or result.choices[0].finish_reason == "length"
-        )
+        choices = getattr(result, "choices", None) or []
+        finish_reason = getattr(choices[0], "finish_reason", None) if choices else None
+        end_openai = provider_type == "openai" and finish_reason in {"stop", "length"}
 
         if end_anthropic or end_openai:
             request_id = promptlayer_api_request(
@@ -1212,6 +1255,9 @@ class GeneratorProxy:
             return result, None
 
         return result
+
+    def _should_propagate_managed_span_context(self):
+        return self.api_request_arugments["provider_type"] in _GENERATOR_PROXY_PROVIDER_TYPES
 
     def cleaned_result(self):
         provider_type = self.api_request_arugments["provider_type"]
@@ -1349,14 +1395,23 @@ async def async_wrapper(
     tags,
     llm_request_span_id: str = None,
     tracer=None,
+    managed_request_span: bool = False,
     *args,
     **kwargs,
 ):
-    current_context = context.get_current()
-    token = context.attach(current_context)
+    token = None
+    try:
+        current_context = context.get_current()
+        token = context.attach(current_context)
+    except Exception:
+        logger.debug("PromptLayer could not attach async tracing context", exc_info=True)
 
     try:
-        response = await coroutine_obj
+        with _mark_genai_request_span(
+            enabled=managed_request_span,
+            request_log_span_id=llm_request_span_id,
+        ):
+            response = await coroutine_obj
         request_end_time = datetime.datetime.now().timestamp()
         result = await promptlayer_api_handler_async(
             api_key,
@@ -1374,13 +1429,20 @@ async def async_wrapper(
         )
 
         if tracer:
-            current_span = trace.get_current_span()
-            if current_span:
-                current_span.set_attribute("function_output", str(result))
+            try:
+                current_span = trace.get_current_span()
+                if current_span:
+                    current_span.set_attribute("function_output", str(result))
+            except Exception:
+                logger.debug("PromptLayer could not annotate an async tracing span", exc_info=True)
 
         return result
     finally:
-        context.detach(token)
+        if token is not None:
+            try:
+                context.detach(token)
+            except Exception:
+                logger.debug("PromptLayer could not detach async tracing context", exc_info=True)
 
 
 @retry_on_api_error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ claude-agent-sdk = {version = ">=0.1.45,<1.0.0", optional = true, python = ">=3.
 opentelemetry-instrumentation-genai-openai = {version = ">=1.0b0,<1.1b0", optional = true, python = ">=3.10,<4.0"}
 opentelemetry-instrumentation-genai-anthropic = {version = ">=1.0b0,<1.1b0", optional = true, python = ">=3.10,<4.0"}
 opentelemetry-instrumentation-google-genai = {version = ">=1.0b1,<1.1b0", optional = true, python = ">=3.10,<4.0"}
+opentelemetry-instrumentation-botocore = {version = "0.65b0", optional = true, python = ">=3.10,<4.0"}
 eval-type-backport = {version = "^0.3.1", optional = true}
 jinja2 = "^3.1.6"
 rich = ">=13.0.0"
@@ -68,6 +69,7 @@ otel-genai-instrumentation = [
     "opentelemetry-instrumentation-genai-openai",
     "opentelemetry-instrumentation-genai-anthropic",
     "opentelemetry-instrumentation-google-genai",
+    "opentelemetry-instrumentation-botocore",
 ]
 openai-agents = ["openai-agents", "eval-type-backport"]
 claude-agents = ["claude-agent-sdk"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "promptlayer"
-version = "1.5.4"
+version = "1.5.5"
 description = "PromptLayer is a platform for prompt engineering and tracks your LLM requests."
 authors = ["Magniv <hello@magniv.io>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,9 @@ tenacity = "^9.1.2"
 cachetools = "^5.0.0"
 openai-agents = {version = "^0.3.3", optional = true}
 claude-agent-sdk = {version = ">=0.1.45,<1.0.0", optional = true, python = ">=3.10,<4.0"}
-opentelemetry-instrumentation-openai-v2 = {version = ">=2.4b0,<2.5b0", optional = true, python = ">=3.10,<4.0"}
+opentelemetry-instrumentation-genai-openai = {version = ">=1.0b0,<1.1b0", optional = true, python = ">=3.10,<4.0"}
+opentelemetry-instrumentation-genai-anthropic = {version = ">=1.0b0,<1.1b0", optional = true, python = ">=3.10,<4.0"}
+opentelemetry-instrumentation-google-genai = {version = ">=1.0b1,<1.1b0", optional = true, python = ">=3.10,<4.0"}
 eval-type-backport = {version = "^0.3.1", optional = true}
 jinja2 = "^3.1.6"
 rich = ">=13.0.0"
@@ -45,7 +47,7 @@ pytest-asyncio = "^0.23.6"
 openai = "^1.107.1"
 openai-agents = "^0.3.3"
 eval-type-backport = "^0.3.1"
-google-genai = "^1.5.0"
+google-genai = ">=1.32,<3"
 anthropic = {extras = ["vertex"], version = "^0.84.0"}
 # TODO(dmu) MEDIUM: Upgrade to vcrpy >= 7 once it supports urllib3 >= 2.2.2
 vcrpy = "<7.0.0"
@@ -59,7 +61,11 @@ boto3 = "^1.35.0"
 aioboto3 = "^13.0.0"
 
 [tool.poetry.extras]
-otel-genai-instrumentation = ["opentelemetry-instrumentation-openai-v2"]
+otel-genai-instrumentation = [
+    "opentelemetry-instrumentation-genai-openai",
+    "opentelemetry-instrumentation-genai-anthropic",
+    "opentelemetry-instrumentation-google-genai",
+]
 openai-agents = ["openai-agents", "eval-type-backport"]
 claude-agents = ["claude-agent-sdk"]
 

--- a/scripts/bedrock-test.py
+++ b/scripts/bedrock-test.py
@@ -1,0 +1,35 @@
+import os
+
+import boto3
+
+from promptlayer import configure_tracing
+
+os.environ.setdefault("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "SPAN_ONLY")
+tracer_provider = configure_tracing(providers=("bedrock",))
+client = boto3.client("bedrock-runtime", region_name="us-east-1")
+
+models = [
+    # "anthropic.claude-sonnet-4-6",
+    "global.anthropic.claude-sonnet-5",
+    # "global.openai.gpt-oss-20b-1:0",
+    # "global.openai.gpt-oss-120b-1:0",
+]
+
+try:
+    for model_id in models:
+        try:
+            response = client.converse(
+                modelId=model_id,
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [{"text": f"Reply exactly: otel-ok-{model_id}"}],
+                    }
+                ],
+                inferenceConfig={"maxTokens": 32},
+            )
+            print(model_id, response["usage"], response["output"]["message"])
+        except Exception as exc:
+            print(model_id, type(exc).__name__, exc)
+finally:
+    print("promptlayer traces flushed:", tracer_provider.force_flush(timeout_millis=10_000))

--- a/tests/test_genai_auto_instrumentation.py
+++ b/tests/test_genai_auto_instrumentation.py
@@ -1,3 +1,4 @@
+import json
 import os
 from weakref import WeakKeyDictionary
 
@@ -255,6 +256,90 @@ def test_anthropic_messages_api_emits_enriched_span(monkeypatch):
         _assert_prompt_attributes(spans[0])
     finally:
         client.close()
+        instrumentor.uninstrument()
+        provider.shutdown()
+
+
+def test_bedrock_converse_emits_enriched_span(monkeypatch):
+    boto3 = pytest.importorskip("boto3")
+    botocore_stub = pytest.importorskip("botocore.stub")
+    instrumentation = pytest.importorskip("opentelemetry.instrumentation.botocore")
+    instrumentor = instrumentation.BotocoreInstrumentor()
+    if instrumentor.is_instrumented_by_opentelemetry:
+        pytest.skip("Botocore SDK is already instrumented by this test process")
+
+    monkeypatch.setenv("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "SPAN_ONLY")
+    provider, exporter = _configure_in_memory_export(monkeypatch, "bedrock")
+    client = boto3.client(
+        "bedrock-runtime",
+        region_name="us-east-1",
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+    )
+    request = {
+        "modelId": "global.anthropic.claude-sonnet-5",
+        "messages": [
+            {
+                "role": "user",
+                "content": [{"text": "Say hello."}],
+            }
+        ],
+        "inferenceConfig": {"maxTokens": 32},
+    }
+    response = {
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [{"text": "Hello."}],
+            }
+        },
+        "stopReason": "end_turn",
+        "usage": {
+            "inputTokens": 2,
+            "outputTokens": 1,
+            "totalTokens": 3,
+        },
+        "metrics": {"latencyMs": 1},
+        "ResponseMetadata": {
+            "RequestId": "bedrock-test-request",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {},
+            "RetryAttempts": 0,
+        },
+    }
+
+    try:
+        _set_test_prompt()
+        with botocore_stub.Stubber(client) as stubber:
+            stubber.add_response("converse", response, request)
+            result = client.converse(**request)
+
+        spans = exporter.get_finished_spans()
+        assert result["output"]["message"]["content"][0]["text"] == "Hello."
+        assert len(spans) == 1
+        assert spans[0].name == "chat global.anthropic.claude-sonnet-5"
+        assert spans[0].attributes["gen_ai.provider.name"] == "aws.bedrock"
+        assert spans[0].attributes["gen_ai.operation.name"] == "chat"
+        assert spans[0].attributes["gen_ai.usage.input_tokens"] == 2
+        assert spans[0].attributes["gen_ai.usage.output_tokens"] == 1
+        assert json.loads(spans[0].attributes["gen_ai.input.messages"]) == [
+            {
+                "role": "user",
+                "parts": [{"type": "text", "content": "Say hello."}],
+            }
+        ]
+        assert json.loads(spans[0].attributes["gen_ai.output.messages"]) == [
+            {
+                "role": "assistant",
+                "parts": [{"type": "text", "content": "Hello."}],
+                "finish_reason": "end_turn",
+            }
+        ]
+        assert spans[0].attributes["promptlayer.provider.type"] == "amazon.bedrock"
+        assert spans[0].attributes["promptlayer.api.type"] == "converse"
+        assert spans[0].attributes["node_type"] == "LLM_CALL"
+        _assert_prompt_attributes(spans[0])
+    finally:
         instrumentor.uninstrument()
         provider.shutdown()
 

--- a/tests/test_genai_auto_instrumentation.py
+++ b/tests/test_genai_auto_instrumentation.py
@@ -1,0 +1,332 @@
+import os
+from weakref import WeakKeyDictionary
+
+import httpx
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import (
+    SimpleSpanProcessor,
+    SpanExporter,
+    SpanExportResult,
+)
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from promptlayer import tracing
+from promptlayer.span_exporter import set_prompt_span_attributes
+
+
+@pytest.fixture(autouse=True)
+def reset_tracing_state(monkeypatch):
+    monkeypatch.setattr(tracing, "_exporter_settings", WeakKeyDictionary())
+    monkeypatch.setattr(tracing, "_prompt_processor_providers", WeakKeyDictionary())
+    monkeypatch.setattr(tracing, "_instrumented_provider_owners", {})
+    original_semconv = os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN")
+    yield
+    if original_semconv is None:
+        os.environ.pop("OTEL_SEMCONV_STABILITY_OPT_IN", None)
+    else:
+        os.environ["OTEL_SEMCONV_STABILITY_OPT_IN"] = original_semconv
+
+
+def _configure_in_memory_export(monkeypatch, provider_name):
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    monkeypatch.setattr(tracing, "OTLPSpanExporter", lambda **_kwargs: exporter)
+    monkeypatch.setattr(
+        tracing,
+        "BatchSpanProcessor",
+        lambda configured_exporter: SimpleSpanProcessor(configured_exporter),
+    )
+    tracing.configure_tracing(
+        api_key="pl-test",
+        tracer_provider=provider,
+        providers=(provider_name,),
+    )
+    return provider, exporter
+
+
+def _set_test_prompt():
+    set_prompt_span_attributes(
+        {"id": 42, "version": 3},
+        "support-answer",
+        label="production",
+    )
+
+
+def _assert_prompt_attributes(span):
+    assert span.attributes["promptlayer.prompt.name"] == "support-answer"
+    assert span.attributes["promptlayer.prompt.id"] == "42"
+    assert span.attributes["promptlayer.prompt.version"] == "3"
+    assert span.attributes["promptlayer.prompt.label"] == "production"
+
+
+class _FailingExporter(SpanExporter):
+    def __init__(self):
+        self.export_calls = 0
+
+    def export(self, spans):
+        self.export_calls += 1
+        return SpanExportResult.FAILURE
+
+
+def test_failed_trace_export_does_not_affect_openai_response(monkeypatch):
+    openai = pytest.importorskip("openai")
+    instrumentation = pytest.importorskip("opentelemetry.instrumentation.genai.openai")
+    instrumentor = instrumentation.OpenAIInstrumentor()
+    if instrumentor.is_instrumented_by_opentelemetry:
+        pytest.skip("OpenAI SDK is already instrumented by this test process")
+
+    exporter = _FailingExporter()
+    provider = TracerProvider()
+    monkeypatch.setattr(tracing, "OTLPSpanExporter", lambda **_kwargs: exporter)
+    tracing.configure_tracing(
+        api_key="pl-test",
+        tracer_provider=provider,
+        providers=("openai",),
+    )
+
+    def handle_request(_request):
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-test",
+                "object": "chat.completion",
+                "created": 1,
+                "model": "gpt-4o-mini",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "Hello.",
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 2,
+                    "completion_tokens": 1,
+                    "total_tokens": 3,
+                },
+            },
+        )
+
+    http_client = httpx.Client(transport=httpx.MockTransport(handle_request))
+    client = openai.OpenAI(
+        api_key="sk-test",
+        base_url="https://openai.test/v1",
+        http_client=http_client,
+    )
+
+    try:
+        completion = client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "Say hello."}],
+        )
+
+        assert completion.choices[0].message.content == "Hello."
+        assert provider.force_flush() is True
+        assert exporter.export_calls == 1
+    finally:
+        client.close()
+        instrumentor.uninstrument()
+        provider.shutdown()
+
+
+def test_openai_responses_api_emits_enriched_span(monkeypatch):
+    openai = pytest.importorskip("openai")
+    instrumentation = pytest.importorskip("opentelemetry.instrumentation.genai.openai")
+    instrumentor = instrumentation.OpenAIInstrumentor()
+    if instrumentor.is_instrumented_by_opentelemetry:
+        pytest.skip("OpenAI SDK is already instrumented by this test process")
+
+    provider, exporter = _configure_in_memory_export(monkeypatch, "openai")
+
+    def handle_request(_request):
+        return httpx.Response(
+            200,
+            json={
+                "id": "resp-test",
+                "created_at": 1.0,
+                "model": "gpt-4o-mini",
+                "object": "response",
+                "output": [
+                    {
+                        "id": "msg-test",
+                        "type": "message",
+                        "role": "assistant",
+                        "status": "completed",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "annotations": [],
+                                "logprobs": [],
+                                "text": "Hello.",
+                            }
+                        ],
+                    }
+                ],
+                "parallel_tool_calls": False,
+                "tool_choice": "auto",
+                "tools": [],
+                "temperature": 1.0,
+                "top_p": 1.0,
+                "usage": {
+                    "input_tokens": 2,
+                    "input_tokens_details": {"cached_tokens": 0},
+                    "output_tokens": 1,
+                    "output_tokens_details": {"reasoning_tokens": 0},
+                    "total_tokens": 3,
+                },
+            },
+        )
+
+    http_client = httpx.Client(transport=httpx.MockTransport(handle_request))
+    client = openai.OpenAI(
+        api_key="sk-test",
+        base_url="https://openai.test/v1",
+        http_client=http_client,
+    )
+
+    try:
+        _set_test_prompt()
+        response = client.responses.create(model="gpt-4o-mini", input="Say hello.")
+
+        spans = exporter.get_finished_spans()
+        assert response.output_text == "Hello."
+        assert len(spans) == 1
+        assert spans[0].attributes["gen_ai.provider.name"] == "openai"
+        assert spans[0].attributes["gen_ai.operation.name"] == "chat"
+        assert spans[0].attributes["promptlayer.provider.type"] == "openai"
+        assert spans[0].attributes["promptlayer.api.type"] == "responses"
+        _assert_prompt_attributes(spans[0])
+    finally:
+        client.close()
+        instrumentor.uninstrument()
+        provider.shutdown()
+
+
+def test_anthropic_messages_api_emits_enriched_span(monkeypatch):
+    anthropic = pytest.importorskip("anthropic")
+    instrumentation = pytest.importorskip("opentelemetry.instrumentation.genai.anthropic")
+    instrumentor = instrumentation.AnthropicInstrumentor()
+    if instrumentor.is_instrumented_by_opentelemetry:
+        pytest.skip("Anthropic SDK is already instrumented by this test process")
+
+    provider, exporter = _configure_in_memory_export(monkeypatch, "anthropic")
+
+    def handle_request(_request):
+        return httpx.Response(
+            200,
+            json={
+                "id": "msg-test",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-sonnet-4-20250514",
+                "content": [{"type": "text", "text": "Hello."}],
+                "stop_reason": "end_turn",
+                "stop_sequence": None,
+                "usage": {"input_tokens": 2, "output_tokens": 1},
+            },
+        )
+
+    http_client = httpx.Client(transport=httpx.MockTransport(handle_request))
+    client = anthropic.Anthropic(
+        api_key="sk-ant-test",
+        base_url="https://anthropic.test",
+        http_client=http_client,
+    )
+
+    try:
+        _set_test_prompt()
+        response = client.messages.create(
+            model="claude-sonnet-4-20250514",
+            max_tokens=32,
+            messages=[{"role": "user", "content": "Say hello."}],
+        )
+
+        spans = exporter.get_finished_spans()
+        assert response.content[0].text == "Hello."
+        assert len(spans) == 1
+        assert spans[0].attributes["gen_ai.provider.name"] == "anthropic"
+        assert spans[0].attributes["gen_ai.operation.name"] == "chat"
+        assert spans[0].attributes["promptlayer.provider.type"] == "anthropic"
+        assert spans[0].attributes["promptlayer.api.type"] == "messages"
+        _assert_prompt_attributes(spans[0])
+    finally:
+        client.close()
+        instrumentor.uninstrument()
+        provider.shutdown()
+
+
+@pytest.mark.parametrize(
+    ("vertexai", "expected_providers"),
+    [
+        (False, {"gemini", "gcp.gemini"}),
+        (True, {"vertex_ai", "gcp.vertex_ai"}),
+    ],
+)
+def test_google_generate_content_emits_enriched_span(
+    monkeypatch,
+    vertexai,
+    expected_providers,
+):
+    genai = pytest.importorskip("google.genai")
+    google_types = pytest.importorskip("google.genai.types")
+    google_models = pytest.importorskip("google.genai.models")
+    instrumentation = pytest.importorskip("opentelemetry.instrumentation.google_genai")
+    instrumentor = instrumentation.GoogleGenAiSdkInstrumentor()
+    if instrumentor.is_instrumented_by_opentelemetry:
+        pytest.skip("Google GenAI SDK is already instrumented by this test process")
+
+    def generate_content(_self, *, model, contents, config=None):
+        del model, contents, config
+        return google_types.GenerateContentResponse(
+            candidates=[
+                google_types.Candidate(
+                    content=google_types.Content(
+                        role="model",
+                        parts=[google_types.Part(text="Hello.")],
+                    ),
+                    finish_reason=google_types.FinishReason.STOP,
+                )
+            ],
+            usage_metadata=google_types.GenerateContentResponseUsageMetadata(
+                prompt_token_count=2,
+                candidates_token_count=1,
+                total_token_count=3,
+            ),
+        )
+
+    monkeypatch.setattr(google_models.Models, "generate_content", generate_content)
+    provider, exporter = _configure_in_memory_export(monkeypatch, "google")
+    if vertexai:
+        google_auth = pytest.importorskip("google.auth.credentials")
+        client = genai.Client(
+            vertexai=True,
+            project="test-project",
+            location="us-central1",
+            credentials=google_auth.AnonymousCredentials(),
+        )
+    else:
+        client = genai.Client(api_key="google-test")
+
+    try:
+        _set_test_prompt()
+        response = client.models.generate_content(
+            model="gemini-2.5-flash",
+            contents="Say hello.",
+        )
+
+        spans = exporter.get_finished_spans()
+        assert response.text == "Hello."
+        assert len(spans) == 1
+        assert spans[0].attributes["gen_ai.provider.name"] in expected_providers
+        assert spans[0].attributes["gen_ai.operation.name"] == "generate_content"
+        assert spans[0].attributes["promptlayer.provider.type"] == ("vertexai" if vertexai else "google")
+        assert spans[0].attributes["promptlayer.api.type"] == "generate-content"
+        _assert_prompt_attributes(spans[0])
+    finally:
+        client.close()
+        instrumentor.uninstrument()
+        provider.shutdown()

--- a/tests/test_genai_tracing.py
+++ b/tests/test_genai_tracing.py
@@ -1,0 +1,664 @@
+import os
+from types import SimpleNamespace
+from unittest.mock import Mock
+from weakref import WeakKeyDictionary
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from promptlayer import tracing
+from promptlayer.promptlayer_base import PromptLayerBase
+from promptlayer.span_exporter import (
+    GenAIPromptTemplateSpanProcessor,
+    _mark_genai_request_span,
+    set_prompt_span_attributes,
+)
+from promptlayer.utils import GeneratorProxy, promptlayer_api_handler
+
+
+class _FakeTracerProvider:
+    def __init__(self):
+        self.processors = []
+        self.tracer = object()
+
+    def add_span_processor(self, processor):
+        self.processors.append(processor)
+
+    def get_tracer(self, *args, **kwargs):
+        return self.tracer
+
+
+@pytest.fixture(autouse=True)
+def reset_tracing_state(monkeypatch):
+    monkeypatch.setattr(tracing, "_exporter_settings", WeakKeyDictionary())
+    monkeypatch.setattr(tracing, "_prompt_processor_providers", WeakKeyDictionary())
+    monkeypatch.setattr(tracing, "_instrumented_provider_owners", {})
+    original_semconv = os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN")
+    yield
+    if original_semconv is None:
+        os.environ.pop("OTEL_SEMCONV_STABILITY_OPT_IN", None)
+    else:
+        os.environ["OTEL_SEMCONV_STABILITY_OPT_IN"] = original_semconv
+
+
+def _install_fake_instrumentors(monkeypatch, provider_names):
+    instrumentors = {}
+    modules = {}
+    sdk_modules = set()
+
+    for provider_name in provider_names:
+        config = tracing._PROVIDER_INSTRUMENTATIONS[provider_name]
+        sdk_modules.add(config.sdk_module)
+        instrumentor = SimpleNamespace(
+            is_instrumented_by_opentelemetry=False,
+            instrument=Mock(),
+        )
+
+        def instrument(*, _instrumentor=instrumentor, **_kwargs):
+            _instrumentor.is_instrumented_by_opentelemetry = True
+
+        instrumentor.instrument.side_effect = instrument
+        instrumentors[provider_name] = instrumentor
+        modules[config.instrumentation_module] = SimpleNamespace(
+            **{config.instrumentor_class: lambda value=instrumentor: value}
+        )
+
+    monkeypatch.setattr(tracing, "_module_available", lambda module_name: module_name in sdk_modules)
+    monkeypatch.setattr(tracing.importlib, "import_module", lambda module_name: modules[module_name])
+    return instrumentors
+
+
+def _capture_otlp_exporters(monkeypatch):
+    exporter_calls = []
+    monkeypatch.setattr(
+        tracing,
+        "OTLPSpanExporter",
+        lambda **kwargs: exporter_calls.append(kwargs) or object(),
+    )
+    monkeypatch.setattr(tracing, "BatchSpanProcessor", lambda exporter: exporter)
+    return exporter_calls
+
+
+def test_configure_tracing_instruments_anthropic_and_google_once(monkeypatch):
+    provider = _FakeTracerProvider()
+    instrumentors = _install_fake_instrumentors(monkeypatch, ("anthropic", "google"))
+    exporter_calls = _capture_otlp_exporters(monkeypatch)
+
+    first = tracing.configure_tracing(
+        api_key="pl_test",
+        tracer_provider=provider,
+        providers=("anthropic", "google"),
+    )
+    second = tracing.configure_tracing(
+        api_key="pl_test",
+        tracer_provider=provider,
+        providers=("anthropic", "google"),
+    )
+
+    assert first is provider
+    assert second is provider
+    assert tracing.NATIVE_OTEL_PROVIDERS == ("openai", "anthropic", "google")
+    assert len(provider.processors) == 2
+    assert isinstance(provider.processors[0], GenAIPromptTemplateSpanProcessor)
+    assert len(exporter_calls) == 1
+    instrumentors["anthropic"].instrument.assert_called_once_with(tracer_provider=provider)
+    instrumentors["google"].instrument.assert_called_once_with(tracer_provider=provider)
+
+
+def test_configure_tracing_instruments_every_installed_provider_by_default(monkeypatch):
+    provider = _FakeTracerProvider()
+    instrumentors = _install_fake_instrumentors(monkeypatch, tracing.NATIVE_OTEL_PROVIDERS)
+    _capture_otlp_exporters(monkeypatch)
+
+    configured_provider = tracing.configure_tracing(
+        api_key="pl_test",
+        tracer_provider=provider,
+    )
+
+    assert configured_provider is provider
+    for instrumentor in instrumentors.values():
+        instrumentor.instrument.assert_called_once_with(tracer_provider=provider)
+
+
+def test_configure_sdk_instrumentation_respects_provider_selection(monkeypatch):
+    provider = _FakeTracerProvider()
+    instrumentors = _install_fake_instrumentors(monkeypatch, ("anthropic", "google"))
+
+    tracing._configure_sdk_instrumentation(
+        provider,
+        providers=("anthropic",),
+    )
+
+    instrumentors["anthropic"].instrument.assert_called_once_with(tracer_provider=provider)
+    instrumentors["google"].instrument.assert_not_called()
+
+
+def test_implicit_instrumentation_failure_does_not_break_tracing_setup(monkeypatch):
+    provider = _FakeTracerProvider()
+    instrumentor = _install_fake_instrumentors(monkeypatch, ("anthropic",))["anthropic"]
+    instrumentor.instrument.side_effect = RuntimeError("instrumentation failed")
+
+    tracing._configure_sdk_instrumentation(provider, providers=("anthropic",))
+
+    instrumentor.instrument.assert_called_once_with(tracer_provider=provider)
+    assert "anthropic" not in tracing._instrumented_provider_owners
+
+
+def test_explicit_instrumentation_failure_is_still_reported(monkeypatch):
+    provider = _FakeTracerProvider()
+    instrumentor = _install_fake_instrumentors(monkeypatch, ("anthropic",))["anthropic"]
+    instrumentor.instrument.side_effect = RuntimeError("instrumentation failed")
+
+    with pytest.raises(RuntimeError, match="instrumentation failed"):
+        tracing._instrument_provider(
+            "anthropic",
+            provider,
+            explicit=True,
+            instrumentor=instrumentor,
+        )
+
+
+def test_configure_sdk_instrumentation_accepts_empty_provider_selection():
+    provider = _FakeTracerProvider()
+
+    tracing._configure_sdk_instrumentation(provider, providers=())
+
+    assert provider.processors == []
+
+
+def test_responses_enrichment_failure_does_not_escape_provider_hook(monkeypatch):
+    class FailingAttributes(dict):
+        def __setitem__(self, key, value):
+            raise RuntimeError("attribute failed")
+
+    apply_request_attributes = Mock()
+    patch_responses = SimpleNamespace(
+        apply_request_attributes=apply_request_attributes,
+    )
+    monkeypatch.setattr(
+        tracing.importlib,
+        "import_module",
+        lambda _module_name: patch_responses,
+    )
+
+    tracing._configure_openai_response_api_enrichment()
+    patch_responses.apply_request_attributes(
+        SimpleNamespace(attributes=FailingAttributes()),
+    )
+
+    apply_request_attributes.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("provider_name", "display_name"),
+    [
+        ("anthropic", "Anthropic"),
+        ("google", "Google GenAI"),
+    ],
+)
+def test_explicit_provider_dependency_failure_does_not_mutate_provider(
+    monkeypatch,
+    provider_name,
+    display_name,
+):
+    provider = _FakeTracerProvider()
+    monkeypatch.setattr(tracing, "_module_available", lambda _module_name: False)
+
+    with pytest.raises(ImportError, match=display_name):
+        tracing.configure_tracing(
+            api_key="pl_test",
+            tracer_provider=provider,
+            providers=(provider_name,),
+        )
+
+    assert provider.processors == []
+
+
+@pytest.mark.parametrize(
+    "provider_name",
+    [
+        "openai",
+        "anthropic",
+        "gemini",
+        "vertex_ai",
+        "gcp.gemini",
+        "gcp.vertex_ai",
+    ],
+)
+def test_genai_prompt_processor_enriches_supported_provider_spans(provider_name):
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(GenAIPromptTemplateSpanProcessor())
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    set_prompt_span_attributes(
+        {"id": 42, "version": 3},
+        "support-answer",
+        label="production",
+    )
+    tracer = provider.get_tracer("opentelemetry.util.genai.handler")
+    with tracer.start_as_current_span(
+        "chat test-model",
+        attributes={"gen_ai.provider.name": provider_name},
+    ):
+        pass
+
+    attributes = dict(exporter.get_finished_spans()[0].attributes)
+    assert attributes["gen_ai.provider.name"] == provider_name
+    assert attributes["promptlayer.prompt.name"] == "support-answer"
+    assert attributes["promptlayer.prompt.id"] == "42"
+    assert attributes["promptlayer.prompt.version"] == "3"
+    assert attributes["promptlayer.prompt.label"] == "production"
+    provider.shutdown()
+
+
+@pytest.mark.parametrize(
+    ("provider_name", "operation_name", "server_address", "expected_provider", "expected_api"),
+    [
+        ("openai", "chat", "api.openai.com", "openai", "chat-completions"),
+        (
+            "openai",
+            "chat",
+            "example.openai.azure.com",
+            "openai.azure",
+            "chat-completions",
+        ),
+        ("anthropic", "chat", "api.anthropic.com", "anthropic", "messages"),
+        (
+            "anthropic",
+            "chat",
+            "us-east5-aiplatform.googleapis.com",
+            "vertexai",
+            "messages",
+        ),
+        (
+            "anthropic",
+            "chat",
+            "notaiplatform.googleapis.com",
+            "anthropic",
+            "messages",
+        ),
+        ("gemini", "generate_content", "generativelanguage.googleapis.com", "google", "generate-content"),
+        ("vertex_ai", "generate_content", "aiplatform.googleapis.com", "vertexai", "generate-content"),
+        ("gemini", "interactions.create", "generativelanguage.googleapis.com", "google", "interactions"),
+        ("gcp.gemini", "embeddings", "generativelanguage.googleapis.com", "google", "embeddings"),
+    ],
+)
+def test_genai_prompt_processor_sets_canonical_provider_and_api(
+    provider_name,
+    operation_name,
+    server_address,
+    expected_provider,
+    expected_api,
+):
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(GenAIPromptTemplateSpanProcessor())
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = provider.get_tracer("opentelemetry.util.genai.handler")
+
+    with tracer.start_as_current_span(
+        "provider request",
+        attributes={
+            "gen_ai.provider.name": provider_name,
+            "gen_ai.operation.name": operation_name,
+            "server.address": server_address,
+        },
+    ):
+        pass
+
+    attributes = dict(exporter.get_finished_spans()[0].attributes)
+    assert attributes["promptlayer.provider.type"] == expected_provider
+    assert attributes["promptlayer.api.type"] == expected_api
+    provider.shutdown()
+
+
+@pytest.mark.parametrize("provider_name", ["anthropic", "gcp.gemini", "gcp.vertex_ai"])
+def test_genai_prompt_processor_links_managed_provider_request(provider_name):
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(GenAIPromptTemplateSpanProcessor())
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = provider.get_tracer("opentelemetry.util.genai.handler")
+
+    with (
+        _mark_genai_request_span(enabled=True, request_log_span_id="abc123"),
+        tracer.start_as_current_span(
+            "chat test-model",
+            attributes={"gen_ai.provider.name": provider_name},
+        ),
+    ):
+        pass
+
+    attributes = dict(exporter.get_finished_spans()[0].attributes)
+    assert attributes["promptlayer.request_log.managed"] is True
+    assert attributes["promptlayer.request_log.span_id"] == "abc123"
+    provider.shutdown()
+
+
+def test_promptlayer_proxy_links_native_provider_span_to_managed_request(monkeypatch):
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(GenAIPromptTemplateSpanProcessor())
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    native_tracer = provider.get_tracer("opentelemetry.util.genai.handler")
+    response = SimpleNamespace(id="message-test")
+
+    def create_message():
+        with native_tracer.start_as_current_span(
+            "chat test-model",
+            attributes={"gen_ai.provider.name": "anthropic"},
+        ):
+            return response
+
+    monkeypatch.setattr(
+        "promptlayer.promptlayer_base.promptlayer_api_handler",
+        lambda *_args, **_kwargs: response,
+    )
+    proxy = PromptLayerBase(
+        api_key="pl-test",
+        base_url="https://api.promptlayer.com",
+        obj=create_message,
+        function_name="anthropic.messages.create",
+        provider_type="anthropic",
+        tracer=provider.get_tracer("test.promptlayer"),
+    )
+
+    assert proxy() is response
+
+    spans_by_name = {span.name: span for span in exporter.get_finished_spans()}
+    request_span = spans_by_name["anthropic.messages.create"]
+    native_span = spans_by_name["chat test-model"]
+    attributes = dict(native_span.attributes)
+    assert attributes["promptlayer.request_log.managed"] is True
+    assert attributes["promptlayer.request_log.span_id"] == format(
+        request_span.context.span_id,
+        "016x",
+    )
+    provider.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_async_promptlayer_proxy_links_native_provider_span_to_managed_request(
+    monkeypatch,
+):
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(GenAIPromptTemplateSpanProcessor())
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    native_tracer = provider.get_tracer("opentelemetry.util.genai.handler")
+    response = SimpleNamespace(id="response-test")
+
+    async def create_response():
+        with native_tracer.start_as_current_span(
+            "chat test-model",
+            attributes={"gen_ai.provider.name": "openai"},
+        ):
+            return response
+
+    async def handle_response(*_args, **_kwargs):
+        return response
+
+    monkeypatch.setattr(
+        "promptlayer.utils.promptlayer_api_handler_async",
+        handle_response,
+    )
+    proxy = PromptLayerBase(
+        api_key="pl-test",
+        base_url="https://api.promptlayer.com",
+        obj=create_response,
+        function_name="openai.responses.create",
+        provider_type="openai",
+        tracer=provider.get_tracer("test.promptlayer"),
+    )
+
+    assert await proxy() is response
+
+    spans_by_name = {span.name: span for span in exporter.get_finished_spans()}
+    request_span = spans_by_name["openai.responses.create"]
+    native_span = spans_by_name["chat test-model"]
+    attributes = dict(native_span.attributes)
+    assert attributes["promptlayer.request_log.managed"] is True
+    assert attributes["promptlayer.request_log.span_id"] == format(
+        request_span.context.span_id,
+        "016x",
+    )
+    provider.shutdown()
+
+
+def test_genai_prompt_processor_ignores_unsupported_provider():
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(GenAIPromptTemplateSpanProcessor())
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    set_prompt_span_attributes({"id": 42, "version": 3}, "support-answer")
+    tracer = provider.get_tracer("opentelemetry.util.genai.handler")
+
+    with tracer.start_as_current_span(
+        "chat test-model",
+        attributes={"gen_ai.provider.name": "unsupported"},
+    ):
+        pass
+
+    attributes = dict(exporter.get_finished_spans()[0].attributes)
+    assert "promptlayer.prompt.name" not in attributes
+    provider.shutdown()
+
+
+@pytest.mark.parametrize(
+    "wrapper_name",
+    [
+        "AsyncChatStreamWrapper",
+        "ResponseStreamManagerWrapper",
+        "AsyncResponseStreamManagerWrapper",
+        "MessagesStreamWrapper",
+        "AsyncMessagesStreamWrapper",
+        "MessagesStreamManagerWrapper",
+        "AsyncMessagesStreamManagerWrapper",
+    ],
+)
+def test_promptlayer_recognizes_genai_instrumentor_stream_wrappers(wrapper_name):
+    response = type(wrapper_name, (), {})()
+
+    result = promptlayer_api_handler(
+        api_key="pl-test",
+        base_url="https://api.promptlayer.com",
+        function_name="provider.stream",
+        provider_type="provider",
+        args=(),
+        kwargs={},
+        tags=[],
+        response=response,
+        request_start_time=1,
+        request_end_time=2,
+    )
+
+    assert isinstance(result, GeneratorProxy)
+    assert result.generator is response
+
+
+def test_promptlayer_delegates_sync_stream_manager_context(monkeypatch):
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(GenAIPromptTemplateSpanProcessor())
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    native_tracer = provider.get_tracer("opentelemetry.util.genai.handler")
+    final_response = SimpleNamespace(id="resp-test")
+    event = SimpleNamespace(type="response.completed", response=final_response)
+
+    class ResponseStream:
+        def __init__(self):
+            self._events = iter([event])
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            return next(self._events)
+
+        def get_final_response(self):
+            return final_response
+
+    class ResponseStreamManagerWrapper:
+        def __init__(self):
+            self.exited = False
+
+        def __enter__(self):
+            with native_tracer.start_as_current_span(
+                "chat streamed-model",
+                attributes={"gen_ai.provider.name": "openai"},
+            ):
+                return ResponseStream()
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            self.exited = True
+            return False
+
+    request = Mock(return_value=17)
+    monkeypatch.setattr("promptlayer.utils.promptlayer_api_request", request)
+    manager = ResponseStreamManagerWrapper()
+    proxy = promptlayer_api_handler(
+        api_key="pl-test",
+        base_url="https://api.promptlayer.com",
+        function_name="openai.responses.create",
+        provider_type="openai",
+        args=(),
+        kwargs={},
+        tags=[],
+        response=manager,
+        request_start_time=1,
+        request_end_time=2,
+        llm_request_span_id="stream-parent",
+    )
+
+    with proxy as stream:
+        assert stream is not None
+        assert list(stream) == [event]
+
+    assert manager.exited is True
+    request.assert_not_called()
+    native_span = exporter.get_finished_spans()[0]
+    assert native_span.attributes["promptlayer.request_log.managed"] is True
+    assert native_span.attributes["promptlayer.request_log.span_id"] == "stream-parent"
+    provider.shutdown()
+
+
+def test_promptlayer_does_not_drain_partially_consumed_stream_manager(monkeypatch):
+    first_event = SimpleNamespace(type="response.output_text.delta")
+
+    class ResponseStream:
+        def __init__(self):
+            self._events = iter([first_event])
+            self.get_final_response = Mock(
+                side_effect=AssertionError("partial stream must not be drained"),
+            )
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            return next(self._events)
+
+    class ResponseStreamManagerWrapper:
+        def __init__(self):
+            self.exited = False
+
+        def __enter__(self):
+            return ResponseStream()
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            self.exited = True
+            return False
+
+    request = Mock()
+    monkeypatch.setattr("promptlayer.utils.promptlayer_api_request", request)
+    manager = ResponseStreamManagerWrapper()
+    proxy = promptlayer_api_handler(
+        api_key="pl-test",
+        base_url="https://api.promptlayer.com",
+        function_name="openai.responses.create",
+        provider_type="openai",
+        args=(),
+        kwargs={},
+        tags=[],
+        response=manager,
+        request_start_time=1,
+        request_end_time=2,
+    )
+
+    with proxy as stream:
+        assert next(stream) is first_event
+
+    assert manager.exited is True
+    request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_promptlayer_delegates_async_stream_manager_context(monkeypatch):
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(GenAIPromptTemplateSpanProcessor())
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    native_tracer = provider.get_tracer("opentelemetry.util.genai.handler")
+    event = SimpleNamespace(type="content_block_delta")
+
+    class AsyncStream:
+        def __init__(self):
+            self._done = False
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if self._done:
+                raise StopAsyncIteration
+            self._done = True
+            return event
+
+    class AsyncMessagesStreamManagerWrapper:
+        def __init__(self):
+            self.exited = False
+
+        async def __aenter__(self):
+            with native_tracer.start_as_current_span(
+                "chat streamed-model",
+                attributes={
+                    "gen_ai.provider.name": "anthropic",
+                    "gen_ai.operation.name": "chat",
+                },
+            ):
+                return AsyncStream()
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            self.exited = True
+            return False
+
+    request = Mock(return_value=18)
+    monkeypatch.setattr("promptlayer.utils.promptlayer_api_request", request)
+    manager = AsyncMessagesStreamManagerWrapper()
+    proxy = promptlayer_api_handler(
+        api_key="pl-test",
+        base_url="https://api.promptlayer.com",
+        function_name="anthropic.messages.stream",
+        provider_type="anthropic",
+        args=(),
+        kwargs={},
+        tags=[],
+        response=manager,
+        request_start_time=1,
+        request_end_time=2,
+        llm_request_span_id="async-stream-parent",
+    )
+
+    async with proxy as stream:
+        assert stream is not None
+        assert [item async for item in stream] == [event]
+
+    assert manager.exited is True
+    request.assert_not_called()
+    native_span = exporter.get_finished_spans()[0]
+    assert native_span.attributes["promptlayer.request_log.managed"] is True
+    assert native_span.attributes["promptlayer.request_log.span_id"] == "async-stream-parent"
+    provider.shutdown()

--- a/tests/test_genai_tracing.py
+++ b/tests/test_genai_tracing.py
@@ -99,7 +99,7 @@ def test_configure_tracing_instruments_anthropic_and_google_once(monkeypatch):
 
     assert first is provider
     assert second is provider
-    assert tracing.NATIVE_OTEL_PROVIDERS == ("openai", "anthropic", "google")
+    assert tracing.NATIVE_OTEL_PROVIDERS == ("openai", "anthropic", "google", "bedrock")
     assert len(provider.processors) == 2
     assert isinstance(provider.processors[0], GenAIPromptTemplateSpanProcessor)
     assert len(exporter_calls) == 1
@@ -118,8 +118,14 @@ def test_configure_tracing_instruments_every_installed_provider_by_default(monke
     )
 
     assert configured_provider is provider
-    for instrumentor in instrumentors.values():
-        instrumentor.instrument.assert_called_once_with(tracer_provider=provider)
+    for provider_name, instrumentor in instrumentors.items():
+        expected_kwargs = {"tracer_provider": provider}
+        if provider_name == "bedrock":
+            expected_kwargs.update(
+                request_hook=tracing.bedrock_request_hook,
+                response_hook=tracing.bedrock_response_hook,
+            )
+        instrumentor.instrument.assert_called_once_with(**expected_kwargs)
 
 
 def test_configure_sdk_instrumentation_respects_provider_selection(monkeypatch):
@@ -133,6 +139,26 @@ def test_configure_sdk_instrumentation_respects_provider_selection(monkeypatch):
 
     instrumentors["anthropic"].instrument.assert_called_once_with(tracer_provider=provider)
     instrumentors["google"].instrument.assert_not_called()
+
+
+@pytest.mark.parametrize("provider_name", ["bedrock", "amazon.bedrock", "aws.bedrock"])
+def test_configure_tracing_accepts_bedrock_provider_aliases(monkeypatch, provider_name):
+    provider = _FakeTracerProvider()
+    instrumentor = _install_fake_instrumentors(monkeypatch, ("bedrock",))["bedrock"]
+    _capture_otlp_exporters(monkeypatch)
+
+    configured_provider = tracing.configure_tracing(
+        api_key="pl_test",
+        tracer_provider=provider,
+        providers=(provider_name,),
+    )
+
+    assert configured_provider is provider
+    instrumentor.instrument.assert_called_once_with(
+        tracer_provider=provider,
+        request_hook=tracing.bedrock_request_hook,
+        response_hook=tracing.bedrock_response_hook,
+    )
 
 
 def test_implicit_instrumentation_failure_does_not_break_tracing_setup(monkeypatch):
@@ -196,6 +222,7 @@ def test_responses_enrichment_failure_does_not_escape_provider_hook(monkeypatch)
     [
         ("anthropic", "Anthropic"),
         ("google", "Google GenAI"),
+        ("bedrock", "AWS Bedrock"),
     ],
 )
 def test_explicit_provider_dependency_failure_does_not_mutate_provider(
@@ -221,6 +248,7 @@ def test_explicit_provider_dependency_failure_does_not_mutate_provider(
     [
         "openai",
         "anthropic",
+        "aws.bedrock",
         "gemini",
         "vertex_ai",
         "gcp.gemini",
@@ -284,6 +312,7 @@ def test_genai_prompt_processor_enriches_supported_provider_spans(provider_name)
         ("vertex_ai", "generate_content", "aiplatform.googleapis.com", "vertexai", "generate-content"),
         ("gemini", "interactions.create", "generativelanguage.googleapis.com", "google", "interactions"),
         ("gcp.gemini", "embeddings", "generativelanguage.googleapis.com", "google", "embeddings"),
+        ("aws.bedrock", "chat", "bedrock-runtime.us-east-1.amazonaws.com", "amazon.bedrock", None),
     ],
 )
 def test_genai_prompt_processor_sets_canonical_provider_and_api(
@@ -311,7 +340,50 @@ def test_genai_prompt_processor_sets_canonical_provider_and_api(
 
     attributes = dict(exporter.get_finished_spans()[0].attributes)
     assert attributes["promptlayer.provider.type"] == expected_provider
+    if expected_api is None:
+        assert "promptlayer.api.type" not in attributes
+    else:
+        assert attributes["promptlayer.api.type"] == expected_api
+    provider.shutdown()
+
+
+@pytest.mark.parametrize(
+    ("rpc_method", "expected_api"),
+    [
+        ("Converse", "converse"),
+        ("ConverseStream", "converse"),
+        ("InvokeModel", "invoke-model"),
+        ("InvokeModelWithResponseStream", "invoke-model"),
+    ],
+)
+def test_genai_prompt_processor_enriches_botocore_bedrock_span(rpc_method, expected_api):
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(GenAIPromptTemplateSpanProcessor())
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = provider.get_tracer("opentelemetry.instrumentation.botocore.bedrock-runtime")
+
+    set_prompt_span_attributes(
+        {"id": 42, "version": 3},
+        "support-answer",
+        label="production",
+    )
+    with tracer.start_as_current_span(
+        "Bedrock Runtime request",
+        attributes={
+            "gen_ai.system": "aws.bedrock",
+            "gen_ai.operation.name": "chat",
+            "rpc.method": rpc_method,
+        },
+    ):
+        pass
+
+    attributes = dict(exporter.get_finished_spans()[0].attributes)
+    assert attributes["gen_ai.provider.name"] == "aws.bedrock"
+    assert attributes["promptlayer.provider.type"] == "amazon.bedrock"
     assert attributes["promptlayer.api.type"] == expected_api
+    assert attributes["promptlayer.prompt.name"] == "support-answer"
+    assert attributes["node_type"] == "LLM_CALL"
     provider.shutdown()
 
 

--- a/tests/test_openai_auto_instrumentation.py
+++ b/tests/test_openai_auto_instrumentation.py
@@ -1,0 +1,94 @@
+import httpx
+import pytest
+from openai import OpenAI
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from promptlayer import PromptLayer
+from promptlayer.span_exporter import (
+    OpenAIPromptTemplateSpanProcessor,
+)
+
+
+def test_direct_openai_client_emits_root_span_with_prompt_template(monkeypatch):
+    instrumentation = pytest.importorskip("opentelemetry.instrumentation.genai.openai")
+    instrumentor = instrumentation.OpenAIInstrumentor()
+    if instrumentor.is_instrumented_by_opentelemetry:
+        pytest.skip("OpenAI SDK is already instrumented by this test process")
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(OpenAIPromptTemplateSpanProcessor())
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    instrumentor.instrument(tracer_provider=provider)
+
+    def handle_request(_request):
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-test",
+                "object": "chat.completion",
+                "created": 1,
+                "model": "gpt-4o-mini",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "Tracing connects work across services.",
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 5,
+                    "completion_tokens": 6,
+                    "total_tokens": 11,
+                },
+            },
+        )
+
+    http_client = httpx.Client(transport=httpx.MockTransport(handle_request))
+    openai_client = OpenAI(
+        api_key="sk-test",
+        base_url="https://openai.test/v1",
+        http_client=http_client,
+    )
+
+    try:
+        prompt_blueprint = {
+            "id": 42,
+            "version": 3,
+            "metadata": {"model": {"provider": "openai"}},
+            "prompt_template": {"type": "chat"},
+            "llm_kwargs": {
+                "model": "gpt-4o-mini",
+                "messages": [{"role": "user", "content": "What is tracing?"}],
+            },
+        }
+        monkeypatch.setattr(
+            "promptlayer.templates.get_prompt_template",
+            lambda *_args, **_kwargs: prompt_blueprint,
+        )
+        promptlayer_client = PromptLayer(api_key="pl-test")
+        prompt = promptlayer_client.templates.get(
+            "support-answer",
+            {"label": "production"},
+        )
+
+        completion = openai_client.chat.completions.create(**prompt["llm_kwargs"])
+
+        spans = exporter.get_finished_spans()
+        assert completion.choices[0].message.content == "Tracing connects work across services."
+        assert len(spans) == 1
+        assert spans[0].parent is None
+        assert spans[0].attributes["gen_ai.provider.name"] == "openai"
+        assert spans[0].attributes["promptlayer.prompt.name"] == "support-answer"
+        assert spans[0].attributes["promptlayer.prompt.id"] == "42"
+        assert spans[0].attributes["promptlayer.prompt.version"] == "3"
+        assert spans[0].attributes["promptlayer.prompt.label"] == "production"
+    finally:
+        openai_client.close()
+        instrumentor.uninstrument()
+        provider.shutdown()

--- a/tests/test_openai_tracing.py
+++ b/tests/test_openai_tracing.py
@@ -460,6 +460,7 @@ def _configure_run_test_client(
     ("promptlayer_provider", "span_provider"),
     [
         ("anthropic", "anthropic"),
+        ("amazon.bedrock", "aws.bedrock"),
         ("google", "gcp.gemini"),
         ("vertexai", "gcp.vertex_ai"),
     ],

--- a/tests/test_openai_tracing.py
+++ b/tests/test_openai_tracing.py
@@ -34,7 +34,7 @@ class _FakeTracerProvider:
 def reset_tracing_state(monkeypatch):
     monkeypatch.setattr(tracing, "_exporter_settings", WeakKeyDictionary())
     monkeypatch.setattr(tracing, "_prompt_processor_providers", WeakKeyDictionary())
-    monkeypatch.setattr(tracing, "_openai_instrumented_provider", None)
+    monkeypatch.setattr(tracing, "_instrumented_provider_owners", {})
     original_semconv = os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN")
     yield
     if original_semconv is None:
@@ -186,12 +186,13 @@ def test_instrument_openai_requires_api_key_before_creating_global_provider(monk
     get_provider.assert_not_called()
 
 
-def test_configure_tracing_rejects_non_openai_provider():
-    with pytest.raises(ValueError, match="Unknown tracing provider: anthropic"):
+@pytest.mark.parametrize("provider_name", ["unsupported", "anthropic.bedrock"])
+def test_configure_tracing_rejects_unknown_provider(provider_name):
+    with pytest.raises(ValueError, match="Unknown tracing provider"):
         tracing.configure_tracing(
             api_key="pl_test",
             tracer_provider=_FakeTracerProvider(),
-            providers=("anthropic",),
+            providers=(provider_name,),
         )
 
 
@@ -222,17 +223,19 @@ def test_openai_prompt_processor_enriches_native_genai_span():
 
 
 def test_promptlayer_recognizes_instrumented_openai_streams():
-    chat_patch = pytest.importorskip("opentelemetry.instrumentation.openai_v2.patch")
-    response_wrappers = pytest.importorskip("opentelemetry.instrumentation.openai_v2.response_wrappers")
+    chat_wrappers = pytest.importorskip("opentelemetry.instrumentation.genai.openai.chat_wrappers")
+    response_wrappers = pytest.importorskip("opentelemetry.instrumentation.genai.openai.response_wrappers")
     wrapper_classes = (
-        chat_patch.ChatStreamWrapper,
-        chat_patch.LegacyChatStreamWrapper,
+        chat_wrappers.ChatStreamWrapper,
+        chat_wrappers.AsyncChatStreamWrapper,
         response_wrappers.ResponseStreamWrapper,
         response_wrappers.AsyncResponseStreamWrapper,
+        response_wrappers.ResponseStreamManagerWrapper,
+        response_wrappers.AsyncResponseStreamManagerWrapper,
     )
 
     for wrapper_class in wrapper_classes:
-        response = object.__new__(wrapper_class)
+        response = type(wrapper_class.__name__, (), {})()
         result = promptlayer_api_handler(
             api_key="pl-test",
             base_url="https://api.promptlayer.com",
@@ -251,7 +254,7 @@ def test_promptlayer_recognizes_instrumented_openai_streams():
 
 
 def test_promptlayer_enable_tracing_auto_instruments_direct_openai(monkeypatch):
-    instrumentation = pytest.importorskip("opentelemetry.instrumentation.openai_v2")
+    instrumentation = pytest.importorskip("opentelemetry.instrumentation.genai.openai")
     instrumentor = instrumentation.OpenAIInstrumentor()
     if instrumentor.is_instrumented_by_opentelemetry:
         pytest.skip("OpenAI SDK is already instrumented by this test process")
@@ -264,6 +267,7 @@ def test_promptlayer_enable_tracing_auto_instruments_direct_openai(monkeypatch):
         "BatchSpanProcessor",
         lambda configured_exporter: SimpleSpanProcessor(configured_exporter),
     )
+    monkeypatch.setattr(tracing, "_module_available", lambda module_name: module_name == "openai")
 
     def handle_request(_request):
         return httpx.Response(
@@ -321,7 +325,7 @@ def test_promptlayer_enable_tracing_auto_instruments_direct_openai(monkeypatch):
 
 
 def test_promptlayer_default_tracing_remains_backward_compatible(monkeypatch):
-    instrumentation = pytest.importorskip("opentelemetry.instrumentation.openai_v2")
+    instrumentation = pytest.importorskip("opentelemetry.instrumentation.genai.openai")
     instrumentor = instrumentation.OpenAIInstrumentor()
     if instrumentor.is_instrumented_by_opentelemetry:
         pytest.skip("OpenAI SDK is already instrumented by this test process")
@@ -332,6 +336,7 @@ def test_promptlayer_default_tracing_remains_backward_compatible(monkeypatch):
         "promptlayer.otlp.BatchSpanProcessor",
         lambda configured_exporter: SimpleSpanProcessor(configured_exporter),
     )
+    monkeypatch.setattr(tracing, "_module_available", lambda module_name: module_name == "openai")
 
     def handle_request(_request):
         return httpx.Response(
@@ -409,7 +414,14 @@ def _promptlayer_run_blueprint():
     }
 
 
-def _configure_run_test_client(client, provider, exporter, monkeypatch, request_function):
+def _configure_run_test_client(
+    client,
+    provider,
+    exporter,
+    monkeypatch,
+    request_function,
+    provider_name="openai",
+):
     provider.add_span_processor(OpenAIPromptTemplateSpanProcessor())
     provider.add_span_processor(SimpleSpanProcessor(exporter))
     client.tracer_provider = provider
@@ -426,8 +438,8 @@ def _configure_run_test_client(client, provider, exporter, monkeypatch, request_
         "_prepare_llm_data",
         Mock(
             return_value={
-                "provider": "openai",
-                "function_name": "openai.chat.completions.create",
+                "provider": provider_name,
+                "function_name": f"{provider_name}.chat",
                 "stream_function": None,
                 "request_function": request_function,
                 "client_kwargs": {},
@@ -438,8 +450,63 @@ def _configure_run_test_client(client, provider, exporter, monkeypatch, request_
     )
 
 
+@pytest.mark.parametrize(
+    ("promptlayer_provider", "span_provider"),
+    [
+        ("anthropic", "anthropic"),
+        ("google", "gcp.gemini"),
+        ("vertexai", "gcp.vertex_ai"),
+    ],
+)
+def test_promptlayer_run_links_managed_genai_span_to_existing_request_log(
+    monkeypatch,
+    promptlayer_provider,
+    span_provider,
+):
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    client = PromptLayer(api_key="pl-test")
+    genai_tracer = provider.get_tracer("opentelemetry.util.genai.handler")
+    response = Mock()
+    response.model_dump.return_value = {"choices": []}
+
+    def request_function(**_kwargs):
+        with genai_tracer.start_as_current_span(
+            "chat test-model",
+            attributes={
+                "gen_ai.provider.name": span_provider,
+                "gen_ai.request.model": "test-model",
+            },
+        ):
+            return response
+
+    _configure_run_test_client(
+        client,
+        provider,
+        exporter,
+        monkeypatch,
+        request_function,
+        provider_name=promptlayer_provider,
+    )
+    track_request = Mock(return_value={"request_id": 17, "prompt_blueprint": {"id": 42}})
+    monkeypatch.setattr("promptlayer.promptlayer.track_request", track_request)
+
+    try:
+        client.run("support-answer")
+
+        spans = {span.name: span for span in exporter.get_finished_spans()}
+        run_span = spans["PromptLayer Run"]
+        genai_span = spans["chat test-model"]
+        run_span_id = f"{run_span.context.span_id:016x}"
+        assert genai_span.attributes["promptlayer.request_log.managed"] is True
+        assert genai_span.attributes["promptlayer.request_log.span_id"] == run_span_id
+        assert track_request.call_args.kwargs["span_id"] == run_span_id
+    finally:
+        provider.shutdown()
+
+
 def test_promptlayer_run_links_managed_openai_span_to_existing_request_log(monkeypatch):
-    instrumentation = pytest.importorskip("opentelemetry.instrumentation.openai_v2")
+    instrumentation = pytest.importorskip("opentelemetry.instrumentation.genai.openai")
     instrumentor = instrumentation.OpenAIInstrumentor()
     if instrumentor.is_instrumented_by_opentelemetry:
         pytest.skip("OpenAI SDK is already instrumented by this test process")
@@ -452,6 +519,7 @@ def test_promptlayer_run_links_managed_openai_span_to_existing_request_log(monke
         "BatchSpanProcessor",
         lambda configured_exporter: SimpleSpanProcessor(configured_exporter),
     )
+    monkeypatch.setattr(tracing, "_module_available", lambda module_name: module_name == "openai")
     client = PromptLayer(
         api_key="pl-test",
         enable_tracing=True,
@@ -553,7 +621,7 @@ def test_promptlayer_run_links_managed_openai_error_span_to_existing_request_log
     exporter = InMemorySpanExporter()
     provider = TracerProvider()
     client = PromptLayer(api_key="pl-test")
-    openai_tracer = provider.get_tracer("opentelemetry.instrumentation.openai_v2")
+    openai_tracer = provider.get_tracer("opentelemetry.util.genai.handler")
 
     def request_function(**_kwargs):
         with openai_tracer.start_as_current_span(
@@ -587,7 +655,7 @@ async def test_async_promptlayer_run_links_managed_openai_span_to_existing_reque
     exporter = InMemorySpanExporter()
     provider = TracerProvider()
     client = AsyncPromptLayer(api_key="pl-test")
-    openai_tracer = provider.get_tracer("opentelemetry.instrumentation.openai_v2")
+    openai_tracer = provider.get_tracer("opentelemetry.util.genai.handler")
     response = Mock()
     response.model_dump.return_value = {"choices": []}
 

--- a/tests/test_openai_tracing.py
+++ b/tests/test_openai_tracing.py
@@ -9,6 +9,7 @@ from openai import OpenAI
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import SpanKind, StatusCode
 
 from promptlayer import AsyncPromptLayer, PromptLayer, instrument_openai, tracing
 from promptlayer.span_exporter import (
@@ -399,7 +400,10 @@ def _promptlayer_run_blueprint():
     return {
         "id": 42,
         "version": 3,
-        "prompt_template": {"type": "chat"},
+        "prompt_template": {
+            "type": "chat",
+            "messages": [{"role": "user", "content": "private template"}],
+        },
         "metadata": {
             "model": {
                 "provider": "openai",
@@ -421,6 +425,7 @@ def _configure_run_test_client(
     monkeypatch,
     request_function,
     provider_name="openai",
+    mock_template=True,
 ):
     provider.add_span_processor(OpenAIPromptTemplateSpanProcessor())
     provider.add_span_processor(SimpleSpanProcessor(exporter))
@@ -432,7 +437,8 @@ def _configure_run_test_client(
         set_prompt_span_attributes(blueprint, prompt_name, label="production")
         return blueprint
 
-    monkeypatch.setattr(client.templates, "get", get_prompt)
+    if mock_template:
+        monkeypatch.setattr(client.templates, "get", get_prompt)
     monkeypatch.setattr(
         client,
         "_prepare_llm_data",
@@ -492,11 +498,33 @@ def test_promptlayer_run_links_managed_genai_span_to_existing_request_log(
     monkeypatch.setattr("promptlayer.promptlayer.track_request", track_request)
 
     try:
-        client.run("support-answer")
+        client.run(
+            "support-answer", prompt_version=2, prompt_release_label="production", metadata={"user_id": "user-7"}
+        )
 
-        spans = {span.name: span for span in exporter.get_finished_spans()}
+        finished_spans = exporter.get_finished_spans()
+        assert len(finished_spans) == 3
+        spans = {span.name: span for span in finished_spans}
         run_span = spans["PromptLayer Run"]
+        fetch_span = spans["Prompt template fetch"]
         genai_span = spans["chat test-model"]
+        assert fetch_span.parent.span_id == genai_span.parent.span_id == run_span.context.span_id
+        assert run_span.context.trace_id == fetch_span.context.trace_id == genai_span.context.trace_id
+        assert run_span.start_time <= fetch_span.start_time <= fetch_span.end_time <= run_span.end_time
+        assert run_span.start_time <= genai_span.start_time <= genai_span.end_time <= run_span.end_time
+        assert run_span.attributes["node_type"] == "CODE_EXECUTION"
+        assert fetch_span.attributes["node_type"] == "PROMPT_TEMPLATE"
+        assert genai_span.attributes["node_type"] == "LLM_CALL"
+        assert fetch_span.kind == SpanKind.INTERNAL
+        assert run_span.attributes["promptlayer.prompt.version"] == "3"
+        assert run_span.attributes["promptlayer.metadata.user_id"] == "user-7"
+        assert fetch_span.attributes["promptlayer.prompt.requested.version"] == "2"
+        for attributes in (run_span.attributes, fetch_span.attributes):
+            assert not any(key.startswith(("gen_ai.", "promptlayer.request_log.")) for key in attributes)
+            assert {"function_input", "function_output"}.isdisjoint(attributes)
+            assert not any(
+                secret in repr(dict(attributes)) for secret in ("private template", "Say hello.", "gpt-4o-mini")
+            )
         run_span_id = f"{run_span.context.span_id:016x}"
         assert genai_span.attributes["promptlayer.request_log.managed"] is True
         assert genai_span.attributes["promptlayer.request_log.span_id"] == run_span_id
@@ -592,7 +620,7 @@ def test_promptlayer_run_links_managed_openai_span_to_existing_request_log(monke
 def test_promptlayer_run_falls_back_to_run_span_without_openai_span(monkeypatch):
     exporter = InMemorySpanExporter()
     provider = TracerProvider()
-    client = PromptLayer(api_key="pl-test")
+    client = PromptLayer(api_key="pl-test", cache_ttl_seconds=60)
     response = Mock()
     response.model_dump.return_value = {"choices": []}
 
@@ -602,17 +630,34 @@ def test_promptlayer_run_falls_back_to_run_span_without_openai_span(monkeypatch)
         exporter,
         monkeypatch,
         lambda **_kwargs: response,
+        mock_template=False,
     )
+    get_prompt = Mock(return_value=_promptlayer_run_blueprint())
+    monkeypatch.setattr("promptlayer.templates.get_prompt_template", get_prompt)
     track_request = Mock(return_value={"request_id": 17, "prompt_blueprint": {"id": 42}})
     monkeypatch.setattr("promptlayer.promptlayer.track_request", track_request)
 
     try:
         client.run("support-answer")
+        client.run("support-answer")
+        error = RuntimeError("template unavailable")
+        monkeypatch.setattr(client.templates, "get", Mock(side_effect=error))
+        with pytest.raises(RuntimeError) as raised:
+            client.run("missing-answer")
 
-        spans = exporter.get_finished_spans()
-        assert len(spans) == 1
-        assert spans[0].name == "PromptLayer Run"
-        assert track_request.call_args.kwargs["span_id"] == f"{spans[0].context.span_id:016x}"
+        finished_spans = exporter.get_finished_spans()
+        run_spans = [span for span in finished_spans if span.name == "PromptLayer Run"]
+        fetch_spans = [span for span in finished_spans if span.name == "Prompt template fetch"]
+        assert raised.value is error
+        assert len(run_spans) == len(fetch_spans) == 3
+        assert [span.attributes.get("promptlayer.prompt.cache_hit") for span in fetch_spans] == [False, True, None]
+        assert get_prompt.call_count == 1
+        assert fetch_spans[-1].status.status_code == run_spans[-1].status.status_code == StatusCode.ERROR
+        assert fetch_spans[-1].attributes["error.type"] == "RuntimeError"
+        assert run_spans[-1].attributes["error.type"] == "RuntimeError"
+        assert [call.kwargs["span_id"] for call in track_request.call_args_list] == [
+            f"{span.context.span_id:016x}" for span in run_spans[:2]
+        ]
     finally:
         provider.shutdown()
 
@@ -703,8 +748,10 @@ async def test_async_promptlayer_run_links_managed_openai_span_to_existing_reque
 
         spans = {span.name: span for span in exporter.get_finished_spans()}
         run_span = spans["PromptLayer Run"]
+        fetch_span = spans["Prompt template fetch"]
         openai_span = spans["chat gpt-4o-mini"]
         assert result["request_id"] == 17
+        assert fetch_span.parent.span_id == run_span.context.span_id
         assert openai_span.parent is not None
         assert openai_span.parent.span_id == run_span.context.span_id
         assert openai_span.attributes["promptlayer.request_log.managed"] is True

--- a/tests/test_otlp_exporter.py
+++ b/tests/test_otlp_exporter.py
@@ -65,11 +65,11 @@ def test_create_promptlayer_tracer_provider_targets_v1_traces(monkeypatch):
 
 def test_initialize_tracer_uses_otlp_exporter(monkeypatch):
     seen = {}
-    instrument_openai = Mock()
+    instrument_genai = Mock()
     monkeypatch.setattr("promptlayer.otlp.OTLPSpanExporter", _FakeExporter(seen))
     monkeypatch.setattr(
-        "promptlayer.promptlayer_mixins._configure_openai_sdk_instrumentation",
-        instrument_openai,
+        "promptlayer.promptlayer_mixins._configure_sdk_instrumentation",
+        instrument_genai,
     )
 
     provider, tracer = PromptLayerMixin._initialize_tracer(
@@ -82,7 +82,7 @@ def test_initialize_tracer_uses_otlp_exporter(monkeypatch):
     assert provider is not None
     assert tracer is not None
     assert seen["endpoint"] == "https://api.promptlayer.com/v1/traces"
-    instrument_openai.assert_called_once_with(provider)
+    instrument_genai.assert_called_once_with(provider, providers=None)
     provider.shutdown()
 
 
@@ -105,6 +105,7 @@ def test_initialize_tracer_uses_explicit_tracer_provider_additively(monkeypatch)
         True,
         enable_tracing=True,
         tracer_provider=provider,
+        tracing_providers=("openai",),
     )
 
     assert configured_provider is provider
@@ -113,6 +114,7 @@ def test_initialize_tracer_uses_explicit_tracer_provider_additively(monkeypatch)
         api_key="pl_test",
         base_url="https://api.promptlayer.com",
         tracer_provider=provider,
+        providers=("openai",),
     )
     initialize_tracer.assert_not_called()
     provider.shutdown()

--- a/tests/test_span_exporter.py
+++ b/tests/test_span_exporter.py
@@ -1,11 +1,16 @@
 """Tests for set_prompt_span_attributes in promptlayer.span_exporter."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 
-from promptlayer.span_exporter import set_prompt_span_attributes
+from promptlayer.span_exporter import (
+    GenAIPromptTemplateSpanProcessor,
+    _mark_genai_request_span,
+    set_prompt_span_attributes,
+)
 
 
 class TestSetPromptSpanAttributes:
@@ -127,3 +132,36 @@ class TestSetPromptSpanAttributes:
             assert "promptlayer.prompt.label" not in attrs
         finally:
             provider.shutdown()
+
+    def test_tracing_attribute_failure_is_best_effort(self):
+        with patch(
+            "promptlayer.span_exporter.trace.get_current_span",
+            side_effect=RuntimeError("broken tracing context"),
+        ):
+            set_prompt_span_attributes({"id": 1, "version": 1}, "my-prompt")
+
+
+def test_genai_span_enrichment_failure_is_best_effort():
+    span = MagicMock(
+        instrumentation_scope=SimpleNamespace(name="opentelemetry.util.genai.handler"),
+        attributes={
+            "gen_ai.provider.name": "openai",
+            "gen_ai.operation.name": "chat",
+        },
+    )
+    span.set_attribute.side_effect = RuntimeError("broken span")
+
+    GenAIPromptTemplateSpanProcessor().on_start(span)
+
+
+def test_genai_request_context_failure_does_not_skip_operation():
+    operation = MagicMock()
+
+    with patch(
+        "promptlayer.span_exporter.context.attach",
+        side_effect=RuntimeError("broken context"),
+    ):
+        with _mark_genai_request_span(enabled=True, request_log_span_id="span-id"):
+            operation()
+
+    operation.assert_called_once_with()

--- a/tests/test_stream_run_tracing.py
+++ b/tests/test_stream_run_tracing.py
@@ -1,4 +1,4 @@
-"""Regression: stream=True must not record the generator as function_output."""
+"""Regression: stream=True must not record function payload attributes."""
 
 from unittest.mock import MagicMock, patch
 
@@ -27,7 +27,7 @@ def test_format_run_output_prefers_prompt_blueprint():
 
 
 @patch("promptlayer.templates.TemplateManager.get")
-def test_sync_run_stream_sets_function_output_after_consume(mock_template_get):
+def test_sync_run_stream_does_not_set_function_output(mock_template_get):
     mock_template_get.return_value = {
         "id": 1,
         "prompt_template": {"type": "chat", "messages": []},
@@ -53,8 +53,6 @@ def test_sync_run_stream_sets_function_output_after_consume(mock_template_get):
 
     with patch.object(client, "_run_internal", return_value=fake_stream()):
         stream = client.run(prompt_name="test_prompt", stream=True)
-        # Before consume, function_output must not be set to the generator.
-        span.set_attribute.assert_any_call("prompt_name", "test_prompt")
         output_calls = [c for c in span.set_attribute.call_args_list if c[0][0] == "function_output"]
         assert output_calls == []
 
@@ -62,15 +60,13 @@ def test_sync_run_stream_sets_function_output_after_consume(mock_template_get):
 
     assert len(chunks) == 2
     output_calls = [c for c in span.set_attribute.call_args_list if c[0][0] == "function_output"]
-    assert len(output_calls) == 1
-    assert "<generator" not in output_calls[0][0][1]
-    assert "hi" in output_calls[0][0][1]
+    assert output_calls == []
     span.end.assert_called_once()
 
 
 @pytest.mark.asyncio
 @patch("promptlayer.templates.AsyncTemplateManager.get")
-async def test_async_run_stream_sets_function_output_after_consume(mock_template_get):
+async def test_async_run_stream_does_not_set_function_output(mock_template_get):
     mock_template_get.return_value = {
         "id": 1,
         "prompt_template": {"type": "chat", "messages": []},
@@ -108,7 +104,5 @@ async def test_async_run_stream_sets_function_output_after_consume(mock_template
 
     assert len(chunks) == 2
     output_calls = [c for c in span.set_attribute.call_args_list if c[0][0] == "function_output"]
-    assert len(output_calls) == 1
-    assert "<async_generator" not in output_calls[0][0][1]
-    assert "bye" in output_calls[0][0][1]
+    assert output_calls == []
     span.end.assert_called_once()


### PR DESCRIPTION
## Summary

- Migrate OpenAI tracing to the official GenAI instrumentor and preserve Responses API attribution.
- Add official Anthropic Messages and Google GenAI auto-instrumentation for Gemini and Vertex AI modes.
- Enrich native provider spans with PromptLayer provider/API attribution, prompt metadata, and managed-request correlation.
- Keep tracing enrichment best-effort and limit stream compatibility changes to official OpenAI and Anthropic wrappers.
- Document the supported APIs and add minimal provider examples and coverage tests.

## Testing

- `poetry run pytest -q` (429 passed, 9 skipped)