### PR TITLE
Fix streamed run span context cleanup

### DIFF
--- a/promptlayer/tracing_context.py
+++ b/promptlayer/tracing_context.py
@@ -6,7 +6,7 @@ import inspect
 from contextvars import ContextVar
 from typing import Any, AsyncGenerator, Generator, Optional
 
-from opentelemetry import trace
+from opentelemetry import context, trace
 from opentelemetry.trace import Tracer
 
 # Set by Eval while a case runner executes. PromptLayer clients resolve this
@@ -53,6 +53,7 @@ def format_run_output(result: Any) -> str:
 
 
 def wrap_stream_with_span(stream: Generator, span) -> Generator:
+    token = context.attach(context.get_current())
     try:
         for chunk in stream:
             yield chunk
@@ -60,10 +61,14 @@ def wrap_stream_with_span(stream: Generator, span) -> Generator:
         span.record_exception(exc)
         raise
     finally:
-        span.end()
+        try:
+            span.end()
+        finally:
+            context.detach(token)
 
 
 async def awrap_stream_with_span(stream: AsyncGenerator, span) -> AsyncGenerator:
+    token = context.attach(context.get_current())
     try:
         async for chunk in stream:
             yield chunk
@@ -71,4 +76,7 @@ async def awrap_stream_with_span(stream: AsyncGenerator, span) -> AsyncGenerator
         span.record_exception(exc)
         raise
     finally:
-        span.end()
+        try:
+            span.end()
+        finally:
+            context.detach(token)

--- a/tests/test_stream_run_tracing.py
+++ b/tests/test_stream_run_tracing.py
@@ -1,11 +1,57 @@
-"""Regression: stream=True must not record function payload attributes."""
+"""Regression coverage for PromptLayer.run(stream=True) tracing."""
 
+import asyncio
+from contextvars import Context
 from unittest.mock import MagicMock, patch
 
 import pytest
+from opentelemetry import context as otel_context, trace as otel_trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from promptlayer import AsyncPromptLayer, PromptLayer
 from promptlayer.tracing_context import format_run_output, is_stream_result
+
+
+def _sync_child_stream(tracer, name):
+    span = tracer.start_span(name)
+    token = otel_context.attach(otel_trace.set_span_in_context(span))
+
+    def stream():
+        try:
+            yield {"raw_response": "chunk"}
+        finally:
+            otel_context.detach(token)
+            span.end()
+
+    return stream()
+
+
+def _async_child_stream(tracer, name):
+    span = tracer.start_span(name)
+    token = otel_context.attach(otel_trace.set_span_in_context(span))
+
+    async def stream():
+        try:
+            yield {"raw_response": "chunk"}
+        finally:
+            otel_context.detach(token)
+            span.end()
+
+    return stream()
+
+
+def _assert_sequential_run_hierarchy(spans, root_span_id, current_span_ids):
+    runs = [span for span in spans if span.name == "PromptLayer Run"]
+    tool = next(span for span in spans if span.name == "Tool: demo")
+    llm_calls = [span for span in spans if span.name.startswith("LLM call")]
+
+    assert current_span_ids == [root_span_id, root_span_id]
+    assert len(runs) == 2
+    assert {span.parent.span_id for span in runs} == {root_span_id}
+    assert tool.parent.span_id == root_span_id
+    assert {span.parent.span_id for span in llm_calls} == {span.context.span_id for span in runs}
 
 
 def test_is_stream_result_detects_generators():
@@ -64,6 +110,37 @@ def test_sync_run_stream_does_not_set_function_output(mock_template_get):
     span.end.assert_called_once()
 
 
+def test_sync_stream_restores_parent_context_between_runs():
+    def exercise_hierarchy():
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        tracer = provider.get_tracer(__name__)
+        client = PromptLayer(api_key="test_key")
+        client.tracer = tracer
+        child_names = iter(("LLM call 1", "LLM call 2"))
+
+        def mock_run_internal(**_kwargs):
+            return _sync_child_stream(tracer, next(child_names))
+
+        current_span_ids = []
+        with patch.object(client, "_run_internal", side_effect=mock_run_internal):
+            with tracer.start_as_current_span("wrangler-turn") as root_span:
+                root_span_id = root_span.get_span_context().span_id
+                list(client.run(prompt_name="test_prompt", stream=True))
+                current_span_ids.append(otel_trace.get_current_span().get_span_context().span_id)
+                with tracer.start_as_current_span("Tool: demo"):
+                    pass
+                list(client.run(prompt_name="test_prompt", stream=True))
+                current_span_ids.append(otel_trace.get_current_span().get_span_context().span_id)
+
+        spans = exporter.get_finished_spans()
+        provider.shutdown()
+        return spans, root_span_id, current_span_ids
+
+    _assert_sequential_run_hierarchy(*Context().run(exercise_hierarchy))
+
+
 @pytest.mark.asyncio
 @patch("promptlayer.templates.AsyncTemplateManager.get")
 async def test_async_run_stream_does_not_set_function_output(mock_template_get):
@@ -106,3 +183,37 @@ async def test_async_run_stream_does_not_set_function_output(mock_template_get):
     output_calls = [c for c in span.set_attribute.call_args_list if c[0][0] == "function_output"]
     assert output_calls == []
     span.end.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_async_stream_restores_parent_context_between_runs():
+    async def exercise_hierarchy():
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        tracer = provider.get_tracer(__name__)
+        client = AsyncPromptLayer(api_key="test_key")
+        client.tracer = tracer
+        child_names = iter(("LLM call 1", "LLM call 2"))
+
+        async def mock_run_internal(**_kwargs):
+            return _async_child_stream(tracer, next(child_names))
+
+        current_span_ids = []
+        with patch.object(client, "_run_internal", side_effect=mock_run_internal):
+            with tracer.start_as_current_span("wrangler-turn") as root_span:
+                root_span_id = root_span.get_span_context().span_id
+                async for _chunk in await client.run(prompt_name="test_prompt", stream=True):
+                    pass
+                current_span_ids.append(otel_trace.get_current_span().get_span_context().span_id)
+                with tracer.start_as_current_span("Tool: demo"):
+                    pass
+                async for _chunk in await client.run(prompt_name="test_prompt", stream=True):
+                    pass
+                current_span_ids.append(otel_trace.get_current_span().get_span_context().span_id)
+
+        spans = exporter.get_finished_spans()
+        provider.shutdown()
+        return spans, root_span_id, current_span_ids
+
+    _assert_sequential_run_hierarchy(*await asyncio.create_task(exercise_hierarchy()))


### PR DESCRIPTION
## Summary

- Keep PromptLayer run and prompt tracing contexts active until a streamed response finishes.
- Unwind sync and async contexts in LIFO order so subsequent spans retain their original parent.
- Add regression coverage for sequential streamed runs with an intervening tool span.

## Testing

- Full test suite: 453 passed, 10 skipped.
- Stream tracing regression tests: 6 passed.
- Pre-commit hooks passed.