### PR TITLE
Normalize eval output extraction

### DIFF
--- a/promptlayer/__init__.py
+++ b/promptlayer/__init__.py
@@ -36,7 +36,7 @@ from .exceptions import (
 from .promptlayer import AsyncPromptLayer, PromptLayer
 from .tracing import NATIVE_OTEL_PROVIDERS, configure_tracing, instrument_openai
 
-__version__ = "1.5.11"
+__version__ = "1.5.13"
 __all__ = [
     "PromptLayer",
     "AsyncPromptLayer",

--- a/promptlayer/evaluations/trace_output.py
+++ b/promptlayer/evaluations/trace_output.py
@@ -75,10 +75,11 @@ def resolve_output_from_trace_row(
     *,
     fallback: Any = None,
 ) -> Any:
-    """Prefer Trace-derived last assistant message; else ``fallback``."""
+    """Use a non-null runner output; otherwise derive the assistant output from Trace."""
+    if fallback is not None:
+        return fallback
     trace = _trace_cell_value(row, columns_by_title_map)
-    derived = extract_last_assistant_message(trace)
-    return fallback if derived is None else derived
+    return extract_last_assistant_message(trace)
 
 
 def _trace_cell_value(
@@ -151,11 +152,25 @@ def _assistant_from_request_response(response: Any) -> Any:
                 if role == "assistant":
                     return _normalize_assistant_message(message)
 
-    # Anthropic Messages API
-    if response.get("type") == "message" or "stop_reason" in response:
-        role = response.get("role")
-        if role in (None, "assistant"):
-            return _normalize_anthropic_response(response)
+    # Anthropic Messages API. Backend-normalized responses intentionally omit
+    # ``type`` and may omit ``stop_reason``, so role + content is the stable shape.
+    role = response.get("role")
+    if role in (None, "assistant") and isinstance(response.get("content"), (str, list)):
+        return _normalize_anthropic_response(response)
+
+    # Legacy Anthropic Completions API.
+    completion = response.get("completion")
+    if isinstance(completion, str):
+        return _maybe_parse_json(completion)
+
+    # Google Gemini / Vertex generate-content.
+    candidates = response.get("candidates")
+    if isinstance(candidates, list) and candidates:
+        candidate = candidates[0]
+        if isinstance(candidate, dict):
+            message = _normalize_google_content(candidate.get("content"))
+            if message is not None:
+                return message
 
     # OpenAI Responses API
     output_list = response.get("output")
@@ -179,6 +194,14 @@ def _assistant_from_request_response(response: Any) -> Any:
                         }
                     ],
                 }
+
+    # Amazon Bedrock Converse.
+    if isinstance(response.get("output"), dict):
+        output = response["output"]
+        message = output.get("message")
+        normalized = _normalize_bedrock_message(message)
+        if normalized is not None:
+            return normalized
 
     return None
 
@@ -229,6 +252,73 @@ def _normalize_anthropic_response(response: Dict[str, Any]) -> Any:
     if text is not None:
         return _maybe_parse_json(text)
     return None
+
+
+def _normalize_google_content(content: Any) -> Any:
+    if not isinstance(content, dict):
+        return None
+    parts = content.get("parts")
+    if not isinstance(parts, list):
+        return None
+
+    text_parts: List[str] = []
+    tool_calls: List[Dict[str, Any]] = []
+    for part in parts:
+        if not isinstance(part, dict):
+            continue
+        if isinstance(part.get("text"), str) and not part.get("thought"):
+            text_parts.append(part["text"])
+        function_call = part.get("function_call")
+        if isinstance(function_call, dict):
+            arguments = function_call.get("args") or {}
+            tool_calls.append(
+                {
+                    "id": function_call.get("id"),
+                    "type": "function",
+                    "function": {
+                        "name": function_call.get("name"),
+                        "arguments": arguments if isinstance(arguments, str) else json.dumps(arguments),
+                    },
+                }
+            )
+
+    text = "\n".join(text_parts) if text_parts else None
+    if tool_calls:
+        return {"content": text, "tool_calls": tool_calls}
+    return _maybe_parse_json(text) if text is not None else None
+
+
+def _normalize_bedrock_message(message: Any) -> Any:
+    if not isinstance(message, dict) or message.get("role", "assistant") != "assistant":
+        return None
+    content = message.get("content")
+    if not isinstance(content, list):
+        return None
+
+    text_parts: List[str] = []
+    tool_calls: List[Dict[str, Any]] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if isinstance(block.get("text"), str):
+            text_parts.append(block["text"])
+        tool_use = block.get("toolUse")
+        if isinstance(tool_use, dict):
+            tool_calls.append(
+                {
+                    "id": tool_use.get("toolUseId"),
+                    "type": "function",
+                    "function": {
+                        "name": tool_use.get("name"),
+                        "arguments": json.dumps(tool_use.get("input") or {}),
+                    },
+                }
+            )
+
+    text = "\n".join(text_parts) if text_parts else None
+    if tool_calls:
+        return {"content": text, "tool_calls": tool_calls}
+    return _maybe_parse_json(text) if text is not None else None
 
 
 def _normalize_responses_message(item: Dict[str, Any]) -> Any:

--- a/promptlayer/evaluations/trace_output.py
+++ b/promptlayer/evaluations/trace_output.py
@@ -257,6 +257,8 @@ def _normalize_anthropic_response(response: Dict[str, Any]) -> Any:
 def _normalize_google_content(content: Any) -> Any:
     if not isinstance(content, dict):
         return None
+    if content.get("role") != "model":
+        return None
     parts = content.get("parts")
     if not isinstance(parts, list):
         return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "promptlayer"
-version = "1.5.12"
+version = "1.5.13"
 description = "PromptLayer is a platform for prompt engineering and tracks your LLM requests."
 authors = ["Magniv <hello@magniv.io>"]
 license = "Apache-2.0"

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -2900,6 +2900,28 @@ def test_extract_last_assistant_message_backend_normalized_providers(request_res
     assert extract_last_assistant_message(trace) == expected
 
 
+def test_extract_last_assistant_message_ignores_google_user_content():
+    from promptlayer.evaluations.trace_output import extract_last_assistant_message
+
+    trace = {
+        "name": "root",
+        "request_log": {
+            "request_response": {
+                "candidates": [
+                    {
+                        "content": {
+                            "role": "user",
+                            "parts": [{"text": "not an assistant response"}],
+                        }
+                    }
+                ]
+            }
+        },
+        "children": [],
+    }
+    assert extract_last_assistant_message(trace) is None
+
+
 def test_resolve_output_prefers_non_null_runner_output_and_uses_trace_for_none():
     from promptlayer.evaluations.trace_output import resolve_output_from_trace_row
 

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -2852,6 +2852,76 @@ def test_extract_last_assistant_message_anthropic():
     assert extract_last_assistant_message(trace) == "hello from anthropic"
 
 
+@pytest.mark.parametrize(
+    ("request_response", "expected"),
+    [
+        (
+            {
+                "role": "assistant",
+                "model": "claude-sonnet-4",
+                "content": [{"type": "text", "text": "normalized anthropic"}],
+            },
+            "normalized anthropic",
+        ),
+        (
+            {
+                "candidates": [
+                    {
+                        "content": {
+                            "role": "model",
+                            "parts": [{"text": "normalized google"}],
+                        }
+                    }
+                ]
+            },
+            "normalized google",
+        ),
+        (
+            {
+                "output": {
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"text": "normalized bedrock"}],
+                    }
+                }
+            },
+            "normalized bedrock",
+        ),
+    ],
+)
+def test_extract_last_assistant_message_backend_normalized_providers(request_response, expected):
+    from promptlayer.evaluations.trace_output import extract_last_assistant_message
+
+    trace = {
+        "name": "root",
+        "request_log": {"request_response": request_response},
+        "children": [],
+    }
+    assert extract_last_assistant_message(trace) == expected
+
+
+def test_resolve_output_prefers_non_null_runner_output_and_uses_trace_for_none():
+    from promptlayer.evaluations.trace_output import resolve_output_from_trace_row
+
+    columns = {"Trace": {"id": "trace-column", "title": "Trace", "type": "TRACE"}}
+    row = {
+        "cells": {
+            "trace-column": {
+                "value": {
+                    "name": "root",
+                    "request_log": {
+                        "request_response": {"choices": [{"message": {"role": "assistant", "content": "from-trace"}}]}
+                    },
+                    "children": [],
+                }
+            }
+        }
+    }
+
+    assert resolve_output_from_trace_row(row, columns, fallback="runner-output") == "runner-output"
+    assert resolve_output_from_trace_row(row, columns, fallback=None) == "from-trace"
+
+
 @patch("promptlayer.evaluations.runner.flush_traces")
 @patch("promptlayer.evaluations.tracing.TracerProvider.get_tracer")
 @patch("promptlayer.tables.api.upsert_table_by_title")


### PR DESCRIPTION
## Summary
- prefer non-null runner output when populating evaluation results
- support backend-normalized Anthropic, Google/Vertex, and Amazon Bedrock trace responses
- bump the Python SDK patch version to 1.5.13

## Test plan
- [x] Run all pre-commit hooks
- [x] Run targeted provider and output precedence tests
- [x] Verify the localhost provider trace matrix

Made with [Cursor](https://cursor.com)