### PR TITLE
Retry dropped connections in the shared HTTP session

### DIFF
--- a/promptlayer/__init__.py
+++ b/promptlayer/__init__.py
@@ -36,7 +36,7 @@ from .exceptions import (
 from .promptlayer import AsyncPromptLayer, PromptLayer
 from .tracing import NATIVE_OTEL_PROVIDERS, configure_tracing, instrument_openai
 
-__version__ = "1.5.13"
+__version__ = "1.5.14"
 __all__ = [
     "PromptLayer",
     "AsyncPromptLayer",

--- a/promptlayer/utils.py
+++ b/promptlayer/utils.py
@@ -35,6 +35,7 @@ from tenacity import (
     stop_after_attempt,
     wait_exponential,
 )
+from urllib3.util.retry import Retry
 
 from promptlayer import exceptions as _exceptions
 from promptlayer.span_exporter import _mark_genai_request_span
@@ -109,10 +110,24 @@ def _get_requests_session() -> requests.Session:
                 # Connection pool configuration - can be tuned via environment variables
                 pool_connections = int(os.getenv("PROMPTLAYER_POOL_CONNECTIONS", 100))
                 pool_maxsize = int(os.getenv("PROMPTLAYER_POOL_MAXSIZE", 100))
+                # Retry dropped connections, e.g. stale keep-alive sockets the server
+                # already closed. urllib3 raises these as a ProtocolError, which it counts
+                # as a read error, so `read` must be set for the retry to fire. POST is
+                # included because both PromptLayer API calls use POST.
+                connection_retries = Retry(
+                    total=2,
+                    connect=2,
+                    read=2,
+                    redirect=0,
+                    status=0,
+                    allowed_methods=frozenset({"GET", "POST"}),
+                    raise_on_status=False,
+                    backoff_factor=0.25,
+                )
                 adapter = requests.adapters.HTTPAdapter(
                     pool_connections=pool_connections,
                     pool_maxsize=pool_maxsize,
-                    max_retries=0,  # We handle retries at application level via should_retry_error()
+                    max_retries=connection_retries,
                 )
                 session.mount("https://", adapter)
                 session.mount("http://", adapter)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "promptlayer"
-version = "1.5.13"
+version = "1.5.14"
 description = "PromptLayer is a platform for prompt engineering and tracks your LLM requests."
 authors = ["Magniv <hello@magniv.io>"]
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- Retry transport-level failures from stale pooled connections.
- Allow retries for GET and POST requests with a short backoff.
- Bump the package version to 1.5.13.

## Testing

- `poetry run pytest tests/test_utils.py -s` (18 passed)