### PR TITLE
Make Eval SDK sheet operation waits websocket-first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added prompt schema types for centralized MCP server references, OpenAI-native MCP tools, tool variables, OpenRouter server tools, expanded OpenAI built-ins, and parent prompt version lineage.
 - Added official OpenTelemetry auto-instrumentation for OpenAI, Anthropic Messages, Google GenAI in Gemini and Vertex AI modes, and AWS Bedrock through Botocore. Message content capture defaults to `SPAN_ONLY` and can be disabled with `NO_CONTENT`.
 - Added public table scorecard APIs under `client.tables.sheets.scorecards`.
 - Existing `/score` compatibility types now allow scorecard fallback and piggyback recalculation responses.

--- a/promptlayer/__init__.py
+++ b/promptlayer/__init__.py
@@ -36,7 +36,7 @@ from .exceptions import (
 from .promptlayer import AsyncPromptLayer, PromptLayer
 from .tracing import NATIVE_OTEL_PROVIDERS, configure_tracing, instrument_openai
 
-__version__ = "1.5.14"
+__version__ = "1.5.15"
 __all__ = [
     "PromptLayer",
     "AsyncPromptLayer",

--- a/promptlayer/cli/eval_cmd.py
+++ b/promptlayer/cli/eval_cmd.py
@@ -25,6 +25,33 @@ def _install_double_sigint_handler() -> None:
     def _handler(signum, frame):  # noqa: ARG001
         global _SIGINT_COUNT
         _SIGINT_COUNT += 1
+        # #region agent log
+        try:
+            import json
+            import time
+
+            with open(
+                "/Users/hasaanmajeed/Documents/promptlayer/prompt-layer-library/.cursor/debug-d605b0.log",
+                "a",
+                encoding="utf-8",
+            ) as log_file:
+                log_file.write(
+                    json.dumps(
+                        {
+                            "sessionId": "d605b0",
+                            "runId": "pre-fix",
+                            "hypothesisId": "D",
+                            "location": "eval_cmd.py:_handler",
+                            "message": "CLI SIGINT handler invoked",
+                            "data": {"sigint_count": _SIGINT_COUNT},
+                            "timestamp": int(time.time() * 1000),
+                        }
+                    )
+                    + "\n"
+                )
+        except Exception:
+            pass
+        # #endregion
         if _SIGINT_COUNT == 1:
             sys.stderr.write("\nAre you sure? Press Ctrl+C again to force quit.\n")
             sys.stderr.flush()

--- a/promptlayer/cli/eval_cmd.py
+++ b/promptlayer/cli/eval_cmd.py
@@ -25,33 +25,6 @@ def _install_double_sigint_handler() -> None:
     def _handler(signum, frame):  # noqa: ARG001
         global _SIGINT_COUNT
         _SIGINT_COUNT += 1
-        # #region agent log
-        try:
-            import json
-            import time
-
-            with open(
-                "/Users/hasaanmajeed/Documents/promptlayer/prompt-layer-library/.cursor/debug-d605b0.log",
-                "a",
-                encoding="utf-8",
-            ) as log_file:
-                log_file.write(
-                    json.dumps(
-                        {
-                            "sessionId": "d605b0",
-                            "runId": "pre-fix",
-                            "hypothesisId": "D",
-                            "location": "eval_cmd.py:_handler",
-                            "message": "CLI SIGINT handler invoked",
-                            "data": {"sigint_count": _SIGINT_COUNT},
-                            "timestamp": int(time.time() * 1000),
-                        }
-                    )
-                    + "\n"
-                )
-        except Exception:
-            pass
-        # #endregion
         if _SIGINT_COUNT == 1:
             sys.stderr.write("\nAre you sure? Press Ctrl+C again to force quit.\n")
             sys.stderr.flush()

--- a/promptlayer/evaluations/live_progress.py
+++ b/promptlayer/evaluations/live_progress.py
@@ -1,0 +1,153 @@
+"""Live Smart Table execution progress via Centrifugo websockets."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
+
+import urllib3
+
+from promptlayer.utils import (
+    _get_websocket_token,
+    centrifugo_client,
+    centrifugo_subscription,
+)
+
+logger = logging.getLogger(__name__)
+
+SMART_TABLE_EXECUTION_STATUS_UPDATE = "SMART_TABLE_EXECUTION_STATUS_UPDATE"
+SMART_SHEET_CHANNEL_TEMPLATE = "smart_sheets:smart_sheet#{sheet_id}"
+_TERMINAL_EXECUTION_STATUSES = frozenset({"completed", "failed", "cancelled"})
+_DEFAULT_SAFETY_POLL_INTERVAL_SECONDS = 5.0
+
+ExecutionUpdateCallback = Callable[[Dict[str, Any]], None]
+SafetyPollCallback = Callable[[], Awaitable[Optional[Dict[str, Dict[str, Any]]]]]
+
+
+def smart_sheet_channel(sheet_id: Any) -> str:
+    return SMART_SHEET_CHANNEL_TEMPLATE.format(sheet_id=sheet_id)
+
+
+def execution_update_to_operation_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Map WS execution status fields onto the public operation status shape."""
+    execution_id = str(payload.get("execution_id") or "")
+    return {
+        "operation_id": execution_id,
+        "execution_id": execution_id,
+        "status": payload.get("status"),
+        "completed_count": payload.get("completed", 0),
+        "failed_count": payload.get("failed", 0),
+        "cell_count": payload.get("total", 0),
+    }
+
+
+def _parse_execution_update(data: Any) -> Optional[Dict[str, Any]]:
+    if isinstance(data, str):
+        try:
+            payload = json.loads(data)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return None
+    elif isinstance(data, dict):
+        payload = data
+    else:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    execution_id = payload.get("execution_id")
+    status = payload.get("status")
+    if execution_id is None or not str(execution_id).strip():
+        return None
+    if not isinstance(status, str) or not status.strip():
+        return None
+    return payload
+
+
+def _is_terminal_status(status: Any) -> bool:
+    return isinstance(status, str) and status.strip().lower() in _TERMINAL_EXECUTION_STATUSES
+
+
+async def await_sheet_execution_progress(
+    *,
+    api_key: str,
+    base_url: str,
+    sheet_id: Any,
+    execution_ids: List[str],
+    on_execution_update: ExecutionUpdateCallback,
+    safety_poll: Optional[SafetyPollCallback] = None,
+    safety_poll_interval_seconds: float = _DEFAULT_SAFETY_POLL_INTERVAL_SECONDS,
+    timeout_seconds: float,
+) -> Dict[str, Dict[str, Any]]:
+    """Subscribe to sheet execution status updates until all tracked IDs are terminal.
+
+    Raises on websocket token/connect/subscribe failure so callers can fall back to REST.
+    """
+    tracked: Set[str] = {str(item) for item in execution_ids if item is not None and str(item).strip()}
+    if not tracked:
+        return {}
+
+    channel_name = smart_sheet_channel(sheet_id)
+    headers = {"X-API-KEY": api_key}
+    websocket_token = await _get_websocket_token(base_url, channel_name, headers)
+    token = websocket_token["token_details"]["token"]
+
+    ws_scheme = "wss" if urllib3.util.parse_url(base_url).scheme == "https" else "ws"
+    address = urllib3.util.parse_url(base_url)._replace(scheme=ws_scheme, path="/connection/websocket").url
+
+    states: Dict[str, Dict[str, Any]] = {execution_id: {} for execution_id in tracked}
+    done = asyncio.Event()
+
+    def _apply_update(execution_id: str, payload: Dict[str, Any]) -> None:
+        states[execution_id] = payload
+        on_execution_update(payload)
+        if all(_is_terminal_status((states[item] or {}).get("status")) for item in tracked):
+            done.set()
+
+    async def message_listener(message_name: str, data: str) -> None:
+        if message_name != SMART_TABLE_EXECUTION_STATUS_UPDATE or done.is_set():
+            return
+        payload = _parse_execution_update(data)
+        if payload is None:
+            return
+        execution_id = str(payload["execution_id"])
+        if execution_id not in tracked:
+            return
+        _apply_update(execution_id, execution_update_to_operation_payload(payload))
+
+    async def safety_poll_loop() -> None:
+        if safety_poll is None:
+            await done.wait()
+            return
+        while not done.is_set():
+            try:
+                await asyncio.wait_for(done.wait(), timeout=safety_poll_interval_seconds)
+                return
+            except asyncio.TimeoutError:
+                pass
+            try:
+                polled = await safety_poll()
+            except Exception:
+                logger.debug("Safety poll for sheet execution progress failed", exc_info=True)
+                continue
+            if not polled:
+                continue
+            for execution_id, payload in polled.items():
+                if execution_id not in tracked or not isinstance(payload, dict):
+                    continue
+                _apply_update(execution_id, payload)
+
+    async with centrifugo_client(address, token) as client:
+        async with centrifugo_subscription(client, channel_name, message_listener):
+            safety_task = asyncio.create_task(safety_poll_loop())
+            try:
+                await asyncio.wait_for(done.wait(), timeout=timeout_seconds)
+            finally:
+                done.set()
+                safety_task.cancel()
+                try:
+                    await safety_task
+                except asyncio.CancelledError:
+                    pass
+
+    return states

--- a/promptlayer/evaluations/live_progress.py
+++ b/promptlayer/evaluations/live_progress.py
@@ -33,14 +33,28 @@ def smart_sheet_channel(sheet_id: Any) -> str:
 def execution_update_to_operation_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
     """Map WS execution status fields onto the public operation status shape."""
     execution_id = str(payload.get("execution_id") or "")
-    return {
+    completed = payload.get("completed", 0)
+    failed = payload.get("failed", 0)
+    total = payload.get("total", 0)
+    mapped = {
         "operation_id": execution_id,
         "execution_id": execution_id,
         "status": payload.get("status"),
-        "completed_count": payload.get("completed", 0),
-        "failed_count": payload.get("failed", 0),
-        "cell_count": payload.get("total", 0),
+        "completed_count": completed,
+        "failed_count": failed,
+        "cell_count": total,
     }
+    # Derive pending when the WS event omits it so count-based terminal
+    # detection matches REST safety-poll payloads.
+    try:
+        completed_n = int(completed)
+        failed_n = int(failed)
+        total_n = int(total)
+    except (TypeError, ValueError):
+        return mapped
+    if completed_n >= 0 and failed_n >= 0 and total_n >= 0:
+        mapped["pending_count"] = max(total_n - completed_n - failed_n, 0)
+    return mapped
 
 
 def _parse_execution_update(data: Any) -> Optional[Dict[str, Any]]:
@@ -64,8 +78,47 @@ def _parse_execution_update(data: Any) -> Optional[Dict[str, Any]]:
     return payload
 
 
-def _is_terminal_status(status: Any) -> bool:
-    return isinstance(status, str) and status.strip().lower() in _TERMINAL_EXECUTION_STATUSES
+def _non_negative_int(value: Any) -> Optional[int]:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed >= 0 else None
+
+
+def _normalize_operation_status_payload(payload: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Unwrap GET /operations/:id which returns ``{"success": true, "operation": {...}}``."""
+    if not isinstance(payload, dict):
+        return payload
+    nested = payload.get("operation")
+    if isinstance(nested, dict):
+        return nested
+    return payload
+
+
+def operation_payload_is_terminal(payload: Optional[Dict[str, Any]]) -> bool:
+    """True when status is terminal, or when cell counts show the operation finished.
+
+    Matches REST polling: Redis status can lag behind finished cells, so treat
+    ``pending_count == 0`` and ``completed + failed >= cell_count`` as done.
+    """
+    payload = _normalize_operation_status_payload(payload)
+    if not isinstance(payload, dict):
+        return False
+    status = payload.get("status")
+    if isinstance(status, str) and status.strip().lower() in _TERMINAL_EXECUTION_STATUSES:
+        return True
+    pending = _non_negative_int(payload.get("pending_count"))
+    completed = _non_negative_int(payload.get("completed_count"))
+    failed = _non_negative_int(payload.get("failed_count"))
+    cell_count = _non_negative_int(payload.get("cell_count"))
+    if pending is None or completed is None or failed is None or cell_count is None:
+        return False
+    if pending > 0:
+        return False
+    return completed + failed >= cell_count
 
 
 async def await_sheet_execution_progress(
@@ -101,7 +154,9 @@ async def await_sheet_execution_progress(
     def _apply_update(execution_id: str, payload: Dict[str, Any]) -> None:
         states[execution_id] = payload
         on_execution_update(payload)
-        if all(_is_terminal_status((states[item] or {}).get("status")) for item in tracked):
+        # Use the same terminal rules as REST polling (status *or* finished counts)
+        # so a safety-poll payload that lags on Redis status still completes the wait.
+        if all(operation_payload_is_terminal(states[item]) for item in tracked):
             done.set()
 
     async def message_listener(message_name: str, data: str) -> None:

--- a/promptlayer/evaluations/polling.py
+++ b/promptlayer/evaluations/polling.py
@@ -443,12 +443,17 @@ def _finalize_live_operation_states(
     states: Dict[str, Dict[str, Any]],
     operation_ids: List[str],
 ) -> Dict[str, Any]:
+    """Validate terminal outcomes without re-reporting progress.
+
+    Live WS / safety-poll updates already call ``_report_operation_cell_progress``.
+    Re-reporting a terminal payload here would print the completed checkmark twice
+    once the spinner has been cleared.
+    """
     last: Dict[str, Any] = {}
     for operation_id in operation_ids:
         payload = states.get(operation_id) or {}
         if isinstance(payload, dict) and payload:
             last = payload
-            _report_operation_cell_progress(payload, _report_terminal_operation_progress)
             _raise_if_operation_failed(operation_id, payload)
     return last
 
@@ -558,6 +563,7 @@ async def await_for_sheet_operations(
         )
 
     # Refresh any non-terminal leftovers via REST before finalizing.
+    # These refreshes were not seen by the live listener, so report progress here.
     for operation_id in operation_ids:
         payload = states.get(operation_id) or {}
         if isinstance(payload, dict) and _operation_is_terminal(payload):
@@ -567,5 +573,6 @@ async def await_for_sheet_operations(
         )
         if isinstance(refreshed, dict):
             states[operation_id] = refreshed
+            _report_operation_cell_progress(refreshed, _report_terminal_operation_progress)
 
     return _finalize_live_operation_states(states, operation_ids)

--- a/promptlayer/evaluations/polling.py
+++ b/promptlayer/evaluations/polling.py
@@ -1,7 +1,9 @@
 import asyncio
+import logging
 import time
 from typing import Any, Callable, Dict, List, Optional
 
+from promptlayer.evaluations.live_progress import await_sheet_execution_progress
 from promptlayer.evaluations.terminal import get_terminal
 from promptlayer.evaluations.utils import (
     _DEFAULT_CELL_WAIT_TIMEOUT_SECONDS,
@@ -12,6 +14,8 @@ from promptlayer.evaluations.utils import (
 from promptlayer.evaluations.validation import api_error, timeout_error
 from promptlayer.tables import api as tables_api
 from promptlayer.types.table import Column, ResourceId
+
+logger = logging.getLogger(__name__)
 
 _TERMINAL_OPERATION_STATUSES = frozenset({"completed", "failed", "cancelled"})
 
@@ -345,98 +349,27 @@ def _report_terminal_operation_progress(
     get_terminal().cell_progress(completed, total, failed, status=status)
 
 
-def wait_for_sheet_operations(
-    api_key: str,
-    base_url: str,
-    throw_on_error: bool,
-    table_id: ResourceId,
-    sheet_id: ResourceId,
-    *,
-    column_ids: List[str],
-    row_ids: Optional[List[int]] = None,
-    timeout_seconds: float = _DEFAULT_CELL_WAIT_TIMEOUT_SECONDS,
-    poll_interval_seconds: float = _DEFAULT_POLL_INTERVAL_SECONDS,
-) -> Optional[Dict[str, Any]]:
-    """Start a scoped recalculate operation and poll until each operation finishes."""
-    if not column_ids:
-        return None
-    create_response = tables_api.create_sheet_operation(
-        api_key,
-        base_url,
-        throw_on_error,
-        table_id,
-        sheet_id,
-        {
-            "operation": "recalculate",
-            "column_ids": column_ids,
-            "row_ids": row_ids,
-        },
-    )
-    _report_operation_cell_progress(create_response, _report_terminal_operation_progress)
-    operation_ids = _operation_ids_from_create_response(create_response if isinstance(create_response, dict) else None)
-    if not operation_ids:
-        if isinstance(create_response, dict):
-            cell_count = _non_negative_int(create_response.get("cell_count")) or 0
-            get_terminal().cell_progress(cell_count, cell_count, 0, status="completed")
-        return create_response if isinstance(create_response, dict) else None
-
-    last: Optional[Dict[str, Any]] = None
-    for operation_id in operation_ids:
-        last = _poll_until(
-            fetch=lambda operation_id=operation_id: _normalize_operation_status_payload(
-                tables_api.get_sheet_operation(api_key, base_url, throw_on_error, table_id, sheet_id, operation_id)
-            ),
-            is_done=_operation_is_terminal,
-            timeout_seconds=timeout_seconds,
-            poll_interval_seconds=poll_interval_seconds,
-            timeout_message="Timed out waiting for supporting column computation to finish.",
-            backoff=True,
-            on_update=lambda payload: _report_operation_cell_progress(payload, _report_terminal_operation_progress),
+def _raise_if_operation_failed(operation_id: str, payload: Optional[Dict[str, Any]]) -> None:
+    status = str((payload or {}).get("status") or "").lower()
+    if status == "failed":
+        raise api_error(f"Supporting column operation {operation_id} failed while computing preprocessing columns.")
+    if status == "cancelled":
+        raise api_error(
+            f"Supporting column operation {operation_id} was cancelled while computing preprocessing columns."
         )
-        status = str((last or {}).get("status") or "").lower()
-        if status == "failed":
-            raise api_error(f"Supporting column operation {operation_id} failed while computing preprocessing columns.")
-        if status == "cancelled":
-            raise api_error(
-                f"Supporting column operation {operation_id} was cancelled while computing preprocessing columns."
-            )
-    return last
 
 
-async def await_for_sheet_operations(
+async def _apoll_sheet_operations(
     api_key: str,
     base_url: str,
     throw_on_error: bool,
     table_id: ResourceId,
     sheet_id: ResourceId,
+    operation_ids: List[str],
     *,
-    column_ids: List[str],
-    row_ids: Optional[List[int]] = None,
-    timeout_seconds: float = _DEFAULT_CELL_WAIT_TIMEOUT_SECONDS,
-    poll_interval_seconds: float = _DEFAULT_POLL_INTERVAL_SECONDS,
+    timeout_seconds: float,
+    poll_interval_seconds: float,
 ) -> Optional[Dict[str, Any]]:
-    if not column_ids:
-        return None
-    create_response = await tables_api.acreate_sheet_operation(
-        api_key,
-        base_url,
-        throw_on_error,
-        table_id,
-        sheet_id,
-        {
-            "operation": "recalculate",
-            "column_ids": column_ids,
-            "row_ids": row_ids,
-        },
-    )
-    _report_operation_cell_progress(create_response, _report_terminal_operation_progress)
-    operation_ids = _operation_ids_from_create_response(create_response if isinstance(create_response, dict) else None)
-    if not operation_ids:
-        if isinstance(create_response, dict):
-            cell_count = _non_negative_int(create_response.get("cell_count")) or 0
-            get_terminal().cell_progress(cell_count, cell_count, 0, status="completed")
-        return create_response if isinstance(create_response, dict) else None
-
     last: Optional[Dict[str, Any]] = None
     for operation_id in operation_ids:
 
@@ -456,11 +389,183 @@ async def await_for_sheet_operations(
             backoff=True,
             on_update=lambda payload: _report_operation_cell_progress(payload, _report_terminal_operation_progress),
         )
-        status = str((last or {}).get("status") or "").lower()
-        if status == "failed":
-            raise api_error(f"Supporting column operation {operation_id} failed while computing preprocessing columns.")
-        if status == "cancelled":
-            raise api_error(
-                f"Supporting column operation {operation_id} was cancelled while computing preprocessing columns."
-            )
+        _raise_if_operation_failed(operation_id, last)
     return last
+
+
+async def _listen_sheet_operations_live_progress(
+    api_key: str,
+    base_url: str,
+    throw_on_error: bool,
+    table_id: ResourceId,
+    sheet_id: ResourceId,
+    operation_ids: List[str],
+    *,
+    timeout_seconds: float,
+) -> Dict[str, Dict[str, Any]]:
+    latest_by_id: Dict[str, Dict[str, Any]] = {}
+
+    def _on_execution_update(payload: Dict[str, Any]) -> None:
+        operation_id = str(payload.get("operation_id") or payload.get("execution_id") or "")
+        if operation_id:
+            latest_by_id[operation_id] = payload
+        _report_operation_cell_progress(payload, _report_terminal_operation_progress)
+
+    async def _safety_poll() -> Optional[Dict[str, Dict[str, Any]]]:
+        updates: Dict[str, Dict[str, Any]] = {}
+        for operation_id in operation_ids:
+            payload = _normalize_operation_status_payload(
+                await tables_api.aget_sheet_operation(
+                    api_key, base_url, throw_on_error, table_id, sheet_id, operation_id
+                )
+            )
+            if isinstance(payload, dict):
+                updates[operation_id] = payload
+        return updates or None
+
+    states = await await_sheet_execution_progress(
+        api_key=api_key,
+        base_url=base_url,
+        sheet_id=sheet_id,
+        execution_ids=operation_ids,
+        on_execution_update=_on_execution_update,
+        safety_poll=_safety_poll,
+        timeout_seconds=timeout_seconds,
+    )
+    merged = {operation_id: dict(states.get(operation_id) or {}) for operation_id in operation_ids}
+    for operation_id, payload in latest_by_id.items():
+        if operation_id in merged and payload:
+            merged[operation_id] = payload
+    return merged
+
+
+def _finalize_live_operation_states(
+    states: Dict[str, Dict[str, Any]],
+    operation_ids: List[str],
+) -> Dict[str, Any]:
+    last: Dict[str, Any] = {}
+    for operation_id in operation_ids:
+        payload = states.get(operation_id) or {}
+        if isinstance(payload, dict) and payload:
+            last = payload
+            _report_operation_cell_progress(payload, _report_terminal_operation_progress)
+            _raise_if_operation_failed(operation_id, payload)
+    return last
+
+
+def wait_for_sheet_operations(
+    api_key: str,
+    base_url: str,
+    throw_on_error: bool,
+    table_id: ResourceId,
+    sheet_id: ResourceId,
+    *,
+    column_ids: List[str],
+    row_ids: Optional[List[int]] = None,
+    statuses: Optional[List[str]] = None,
+    timeout_seconds: float = _DEFAULT_CELL_WAIT_TIMEOUT_SECONDS,
+    poll_interval_seconds: float = _DEFAULT_POLL_INTERVAL_SECONDS,
+) -> Optional[Dict[str, Any]]:
+    """Start a scoped recalculate operation and wait until each operation finishes.
+
+    Uses Centrifugo execution-status updates when available, with REST polling fallback.
+
+    ``statuses`` mirrors the public operations API:
+    - omitted / ``None`` → only ``STALE`` cells (API default)
+    - ``[]`` → no status filter (recalculate all matching cells)
+    - explicit list → only those cell statuses
+    """
+    return asyncio.run(
+        await_for_sheet_operations(
+            api_key,
+            base_url,
+            throw_on_error,
+            table_id,
+            sheet_id,
+            column_ids=column_ids,
+            row_ids=row_ids,
+            statuses=statuses,
+            timeout_seconds=timeout_seconds,
+            poll_interval_seconds=poll_interval_seconds,
+        )
+    )
+
+
+async def await_for_sheet_operations(
+    api_key: str,
+    base_url: str,
+    throw_on_error: bool,
+    table_id: ResourceId,
+    sheet_id: ResourceId,
+    *,
+    column_ids: List[str],
+    row_ids: Optional[List[int]] = None,
+    statuses: Optional[List[str]] = None,
+    timeout_seconds: float = _DEFAULT_CELL_WAIT_TIMEOUT_SECONDS,
+    poll_interval_seconds: float = _DEFAULT_POLL_INTERVAL_SECONDS,
+) -> Optional[Dict[str, Any]]:
+    if not column_ids:
+        return None
+    create_body: Dict[str, Any] = {
+        "operation": "recalculate",
+        "column_ids": column_ids,
+        "row_ids": row_ids,
+    }
+    if statuses is not None:
+        create_body["statuses"] = statuses
+    create_response = await tables_api.acreate_sheet_operation(
+        api_key,
+        base_url,
+        throw_on_error,
+        table_id,
+        sheet_id,
+        create_body,
+    )
+    _report_operation_cell_progress(create_response, _report_terminal_operation_progress)
+    operation_ids = _operation_ids_from_create_response(create_response if isinstance(create_response, dict) else None)
+    if not operation_ids:
+        if isinstance(create_response, dict):
+            cell_count = _non_negative_int(create_response.get("cell_count")) or 0
+            get_terminal().cell_progress(cell_count, cell_count, 0, status="completed")
+        return create_response if isinstance(create_response, dict) else None
+
+    try:
+        states = await _listen_sheet_operations_live_progress(
+            api_key,
+            base_url,
+            throw_on_error,
+            table_id,
+            sheet_id,
+            operation_ids,
+            timeout_seconds=timeout_seconds,
+        )
+    except asyncio.TimeoutError as exc:
+        raise timeout_error("Timed out waiting for supporting column computation to finish.") from exc
+    except Exception as exc:
+        logger.warning(
+            "Live sheet execution progress unavailable; falling back to REST polling: %s",
+            exc,
+        )
+        return await _apoll_sheet_operations(
+            api_key,
+            base_url,
+            throw_on_error,
+            table_id,
+            sheet_id,
+            operation_ids,
+            timeout_seconds=timeout_seconds,
+            poll_interval_seconds=poll_interval_seconds,
+        )
+
+    # Refresh any non-terminal leftovers via REST before finalizing.
+    for operation_id in operation_ids:
+        payload = states.get(operation_id) or {}
+        if isinstance(payload, dict) and _operation_is_terminal(payload):
+            continue
+        refreshed = _normalize_operation_status_payload(
+            await tables_api.aget_sheet_operation(api_key, base_url, throw_on_error, table_id, sheet_id, operation_id)
+        )
+        if isinstance(refreshed, dict):
+            states[operation_id] = refreshed
+
+    return _finalize_live_operation_states(states, operation_ids)

--- a/promptlayer/evaluations/polling.py
+++ b/promptlayer/evaluations/polling.py
@@ -1,7 +1,9 @@
 import asyncio
 import logging
 import time
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Coroutine, Dict, List, Optional, TypeVar
+
+import nest_asyncio
 
 from promptlayer.evaluations.live_progress import await_sheet_execution_progress
 from promptlayer.evaluations.terminal import get_terminal
@@ -18,6 +20,26 @@ from promptlayer.types.table import Column, ResourceId
 logger = logging.getLogger(__name__)
 
 _TERMINAL_OPERATION_STATUSES = frozenset({"completed", "failed", "cancelled"})
+
+_T = TypeVar("_T")
+
+
+def _run_coro_sync(coro: Coroutine[Any, Any, _T]) -> _T:
+    """Run an async coroutine from sync code, including nested event loops (e.g. Jupyter).
+
+    Matches ``PromptLayer.run_workflow``: ``asyncio.run`` alone raises
+    ``RuntimeError`` when a loop is already running, so apply ``nest_asyncio``
+    in that case.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop is not None and loop.is_running():
+        nest_asyncio.apply()
+
+    return asyncio.run(coro)
 
 
 def _iter_cell_updates(
@@ -480,7 +502,7 @@ def wait_for_sheet_operations(
     - ``[]`` → no status filter (recalculate all matching cells)
     - explicit list → only those cell statuses
     """
-    return asyncio.run(
+    return _run_coro_sync(
         await_for_sheet_operations(
             api_key,
             base_url,

--- a/promptlayer/evaluations/polling.py
+++ b/promptlayer/evaluations/polling.py
@@ -5,7 +5,10 @@ from typing import Any, Callable, Coroutine, Dict, List, Optional, TypeVar
 
 import nest_asyncio
 
-from promptlayer.evaluations.live_progress import await_sheet_execution_progress
+from promptlayer.evaluations.live_progress import (
+    await_sheet_execution_progress,
+    operation_payload_is_terminal,
+)
 from promptlayer.evaluations.terminal import get_terminal
 from promptlayer.evaluations.utils import (
     _DEFAULT_CELL_WAIT_TIMEOUT_SECONDS,
@@ -18,8 +21,6 @@ from promptlayer.tables import api as tables_api
 from promptlayer.types.table import Column, ResourceId
 
 logger = logging.getLogger(__name__)
-
-_TERMINAL_OPERATION_STATUSES = frozenset({"completed", "failed", "cancelled"})
 
 _T = TypeVar("_T")
 
@@ -292,23 +293,7 @@ def _normalize_operation_status_payload(payload: Optional[Dict[str, Any]]) -> Op
 
 
 def _operation_is_terminal(payload: Optional[Dict[str, Any]]) -> bool:
-    payload = _normalize_operation_status_payload(payload)
-    if not isinstance(payload, dict):
-        return False
-    status = payload.get("status")
-    if isinstance(status, str) and status.lower() in _TERMINAL_OPERATION_STATUSES:
-        return True
-    # Fallback when Redis status lags behind finished cells.
-    pending = _non_negative_int(payload.get("pending_count"))
-    completed = _non_negative_int(payload.get("completed_count"))
-    failed = _non_negative_int(payload.get("failed_count"))
-    cell_count = _non_negative_int(payload.get("cell_count"))
-    if pending is None or completed is None or failed is None or cell_count is None:
-        return False
-    if pending > 0:
-        return False
-    return completed + failed >= cell_count
-
+    return operation_payload_is_terminal(payload)
 
 def _operation_ids_from_create_response(payload: Optional[Dict[str, Any]]) -> List[str]:
     if not isinstance(payload, dict):

--- a/promptlayer/evaluations/polling.py
+++ b/promptlayer/evaluations/polling.py
@@ -295,6 +295,7 @@ def _normalize_operation_status_payload(payload: Optional[Dict[str, Any]]) -> Op
 def _operation_is_terminal(payload: Optional[Dict[str, Any]]) -> bool:
     return operation_payload_is_terminal(payload)
 
+
 def _operation_ids_from_create_response(payload: Optional[Dict[str, Any]]) -> List[str]:
     if not isinstance(payload, dict):
         return []

--- a/promptlayer/evaluations/runner.py
+++ b/promptlayer/evaluations/runner.py
@@ -1,48 +1,12 @@
 import asyncio
-import json
 import signal
 import threading
-import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 from opentelemetry.sdk.trace import TracerProvider
-
-# #region agent log
-_DEBUG_LOG_PATH = "/Users/hasaanmajeed/Documents/promptlayer/prompt-layer-library/.cursor/debug-d605b0.log"
-
-
-def _debug_log(
-    *,
-    hypothesis_id: str,
-    location: str,
-    message: str,
-    data: Optional[Dict[str, Any]] = None,
-    run_id: str = "pre-fix",
-) -> None:
-    try:
-        with open(_DEBUG_LOG_PATH, "a", encoding="utf-8") as log_file:
-            log_file.write(
-                json.dumps(
-                    {
-                        "sessionId": "d605b0",
-                        "runId": run_id,
-                        "hypothesisId": hypothesis_id,
-                        "location": location,
-                        "message": message,
-                        "data": data or {},
-                        "timestamp": int(time.time() * 1000),
-                    }
-                )
-                + "\n"
-            )
-    except Exception:
-        pass
-
-
-# #endregion
 
 from promptlayer.evaluations.polling import (
     afill_row_cells,
@@ -1232,19 +1196,6 @@ def _finalize_eval(
     return result
 
 
-def _sheet_row_count_from_payload(payload: Any) -> int:
-    if not isinstance(payload, dict):
-        return 0
-    sheet = payload.get("sheet") if isinstance(payload.get("sheet"), dict) else payload
-    if not isinstance(sheet, dict):
-        return 0
-    raw = sheet.get("row_count")
-    try:
-        return max(0, int(raw))
-    except (TypeError, ValueError):
-        return 0
-
-
 def _publish_eval_run_abort_sync(
     *,
     api_key: str,
@@ -1252,31 +1203,13 @@ def _publish_eval_run_abort_sync(
     table_id: ResourceId,
     sheet_id: ResourceId,
     known_written: int = 0,
-    source: str = "unknown",
 ) -> None:
-    """Best-effort: mark populate aborted and align progress after Ctrl+C."""
-    # #region agent log
-    _debug_log(
-        hypothesis_id="B",
-        location="runner.py:_publish_eval_run_abort_sync:entry",
-        message="publish abort called",
-        data={"source": source, "known_written": known_written, "table_id": str(table_id), "sheet_id": str(sheet_id)},
-    )
-    # #endregion
-    written = max(0, int(known_written or 0))
-    try:
-        payload = tables_api.get_sheet(api_key, base_url, False, table_id, sheet_id)
-        written = max(written, _sheet_row_count_from_payload(payload))
-    except Exception as exc:  # noqa: BLE001 - still PATCH abort below
-        # #region agent log
-        _debug_log(
-            hypothesis_id="B",
-            location="runner.py:_publish_eval_run_abort_sync:get_sheet_failed",
-            message="get_sheet failed before abort patch",
-            data={"source": source, "error": type(exc).__name__, "error_msg": str(exc)[:200]},
-        )
-        # #endregion
-        pass
+    """Best-effort: mark populate aborted after Ctrl+C.
+
+    Keep the original planned ``expected_row_count`` so the dashboard can show
+    ``3 of 10`` (written of planned), not a snapped ``3 of 3``.
+    """
+    del known_written  # retained for call-site compatibility
     try:
         tables_api.update_sheet(
             api_key,
@@ -1284,28 +1217,9 @@ def _publish_eval_run_abort_sync(
             False,
             table_id,
             sheet_id,
-            {
-                "eval_run_status": "aborted",
-                "expected_row_count": written,
-            },
+            {"eval_run_status": "aborted"},
         )
-        # #region agent log
-        _debug_log(
-            hypothesis_id="B",
-            location="runner.py:_publish_eval_run_abort_sync:success",
-            message="abort patch succeeded",
-            data={"source": source, "written": written},
-        )
-        # #endregion
-    except Exception as exc:  # noqa: BLE001 - interrupt path must not mask KeyboardInterrupt
-        # #region agent log
-        _debug_log(
-            hypothesis_id="B",
-            location="runner.py:_publish_eval_run_abort_sync:update_failed",
-            message="abort patch failed",
-            data={"source": source, "written": written, "error": type(exc).__name__, "error_msg": str(exc)[:200]},
-        )
-        # #endregion
+    except Exception:  # noqa: BLE001 - interrupt path must not mask KeyboardInterrupt
         return
 
 
@@ -1317,12 +1231,8 @@ async def _publish_eval_run_abort_async(
     sheet_id: ResourceId,
     known_written: int = 0,
 ) -> None:
-    written = max(0, int(known_written or 0))
-    try:
-        payload = await tables_api.aget_sheet(api_key, base_url, False, table_id, sheet_id)
-        written = max(written, _sheet_row_count_from_payload(payload))
-    except Exception:  # noqa: BLE001 - still PATCH abort below
-        pass
+    """Best-effort: mark populate aborted after Ctrl+C (async)."""
+    del known_written  # retained for call-site compatibility
     try:
         await tables_api.aupdate_sheet(
             api_key,
@@ -1330,10 +1240,7 @@ async def _publish_eval_run_abort_async(
             False,
             table_id,
             sheet_id,
-            {
-                "eval_run_status": "aborted",
-                "expected_row_count": written,
-            },
+            {"eval_run_status": "aborted"},
         )
     except Exception:  # noqa: BLE001 - interrupt path must not mask KeyboardInterrupt
         return
@@ -1353,14 +1260,6 @@ def _interrupt_eval_run_abort(
     snapped = {"done": False}
 
     def _handler(signum: int, frame: Any) -> None:
-        # #region agent log
-        _debug_log(
-            hypothesis_id="C",
-            location="runner.py:_interrupt_eval_run_abort:handler",
-            message="SIGINT handler invoked",
-            data={"signum": signum, "already_done": snapped["done"], "written": written_counter[0]},
-        )
-        # #endregion
         if not snapped["done"]:
             snapped["done"] = True
             _publish_eval_run_abort_sync(
@@ -1369,7 +1268,6 @@ def _interrupt_eval_run_abort(
                 table_id=table_id,
                 sheet_id=sheet_id,
                 known_written=written_counter[0],
-                source="sigint_handler",
             )
         if callable(previous):
             previous(signum, frame)
@@ -1378,37 +1276,13 @@ def _interrupt_eval_run_abort(
 
     try:
         signal.signal(signal.SIGINT, _handler)
-        # #region agent log
-        _debug_log(
-            hypothesis_id="C",
-            location="runner.py:_interrupt_eval_run_abort:installed",
-            message="SIGINT handler installed",
-            data={"previous_handler": repr(previous)},
-        )
-        # #endregion
-    except (ValueError, OSError) as exc:
-        # #region agent log
-        _debug_log(
-            hypothesis_id="C",
-            location="runner.py:_interrupt_eval_run_abort:install_failed",
-            message="SIGINT handler install failed",
-            data={"error": type(exc).__name__, "error_msg": str(exc)},
-        )
-        # #endregion
+    except (ValueError, OSError):
         yield
         return
 
     try:
         yield
     finally:
-        # #region agent log
-        _debug_log(
-            hypothesis_id="A",
-            location="runner.py:_interrupt_eval_run_abort:finally",
-            message="SIGINT handler restored; interrupt guard exited",
-            data={"abort_already_published": snapped["done"]},
-        )
-        # #endregion
         try:
             signal.signal(signal.SIGINT, previous)
         except (ValueError, OSError):
@@ -1519,32 +1393,14 @@ def run_eval(
                 )
                 written_counter[0] = len([index for index in row_indices if index is not None])
         except KeyboardInterrupt:
-            # #region agent log
-            _debug_log(
-                hypothesis_id="D",
-                location="runner.py:run_eval:keyboard_interrupt",
-                message="KeyboardInterrupt caught in run_eval case phase",
-                data={"written": written_counter[0]},
-            )
-            # #endregion
             _publish_eval_run_abort_sync(
                 api_key=api_key,
                 base_url=base_url,
                 table_id=table["id"],
                 sheet_id=sheet["id"],
                 known_written=written_counter[0],
-                source="run_eval_except",
             )
             raise
-
-    # #region agent log
-    _debug_log(
-        hypothesis_id="A",
-        location="runner.py:run_eval:post_interrupt_context",
-        message="case phase finished; interrupt guard no longer active",
-        data={"written": written_counter[0]},
-    )
-    # #endregion
 
     # Case writers finished — hand the Running banner off to scorecard/compute.
     tables_api.update_sheet(
@@ -1555,25 +1411,9 @@ def run_eval(
         sheet["id"],
         {"eval_run_status": "completed"},
     )
-    # #region agent log
-    _debug_log(
-        hypothesis_id="E",
-        location="runner.py:run_eval:set_completed",
-        message="eval_run_status set to completed",
-        data={},
-    )
-    # #endregion
 
     processing_ids = _processing_column_ids(columns, context.columns)
     if processing_ids:
-        # #region agent log
-        _debug_log(
-            hypothesis_id="A",
-            location="runner.py:run_eval:preprocessing_start",
-            message="entering preprocessing phase without interrupt guard",
-            data={"processing_ids": processing_ids},
-        )
-        # #endregion
         _emit_status("Computing preprocessing columns")
         wait_for_sheet_operations(
             api_key,

--- a/promptlayer/evaluations/runner.py
+++ b/promptlayer/evaluations/runner.py
@@ -1,4 +1,5 @@
 import asyncio
+import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
@@ -259,6 +260,181 @@ def _execute_cases_sync(
         executor.shutdown(wait=not interrupted, cancel_futures=True)
 
     return [item for item in results if item is not None]
+
+
+def _execute_and_persist_cases_sync(
+    *,
+    name: str,
+    cases: List[EvalCase],
+    runner: Any,
+    tracer_provider: TracerProvider,
+    max_concurrency: int,
+    api_key: str,
+    base_url: str,
+    throw_on_error: bool,
+    table_id: ResourceId,
+    sheet_id: ResourceId,
+    eval_name: str,
+    by_title: Dict[str, Column],
+    custom_field_titles: List[str],
+) -> Tuple[List[CaseExecution], List[Optional[int]]]:
+    """Run cases and write each row as soon as the case finishes.
+
+    Persisting incrementally keeps the dashboard sheet filling during
+    ``runners N/M`` instead of staying blank until every case completes.
+    """
+    total = len(cases)
+    results: List[Optional[CaseExecution]] = [None] * total
+    row_indices: List[Optional[int]] = [None] * total
+    persist_lock = threading.Lock()
+
+    def _run_and_persist(index: int, case: EvalCase) -> Tuple[int, CaseExecution, Optional[int]]:
+        input_value = case["input"]
+        expected_value = case.get("expected")
+        expected_trace_value = case.get("expected_trace")
+        output_value, trace_id, span_id = run_case_in_span(
+            name,
+            runner,
+            input_value,
+            tracer_provider,
+            table_id=table_id,
+            sheet_id=sheet_id,
+        )
+        executed = CaseExecution(
+            input=input_value,
+            expected=expected_value,
+            expected_trace=expected_trace_value,
+            dataset_fields=custom_eval_field_values(case),
+            output=output_value,
+            trace_id=trace_id,
+            span_id=span_id,
+        )
+        with persist_lock:
+            indices, _rows, updated = _persist_trace_rows_sync(
+                api_key=api_key,
+                base_url=base_url,
+                throw_on_error=throw_on_error,
+                table_id=table_id,
+                sheet_id=sheet_id,
+                eval_name=eval_name,
+                executed=[executed],
+                by_title=by_title,
+                custom_field_titles=custom_field_titles,
+                tracer_provider=tracer_provider,
+            )
+        return index, updated[0], indices[0] if indices else None
+
+    workers = max(1, min(max_concurrency, total or 1))
+    completed = 0
+    _emit_runners_start(total)
+    if workers == 1:
+        for index, case in enumerate(cases):
+            result_index, executed, row_index = _run_and_persist(index, case)
+            results[result_index] = executed
+            row_indices[result_index] = row_index
+            completed += 1
+            _emit_runner_progress(completed, total)
+        return (
+            [item for item in results if item is not None],
+            [row_indices[i] for i, item in enumerate(results) if item is not None],
+        )
+
+    executor = ThreadPoolExecutor(max_workers=workers)
+    futures = [executor.submit(_run_and_persist, index, case) for index, case in enumerate(cases)]
+    interrupted = False
+    try:
+        for future in as_completed(futures):
+            index, executed, row_index = future.result()
+            results[index] = executed
+            row_indices[index] = row_index
+            completed += 1
+            _emit_runner_progress(completed, total)
+    except KeyboardInterrupt:
+        interrupted = True
+        for future in futures:
+            future.cancel()
+        raise
+    finally:
+        executor.shutdown(wait=not interrupted, cancel_futures=True)
+
+    return [item for item in results if item is not None], [
+        row_indices[i] for i, item in enumerate(results) if item is not None
+    ]
+
+
+async def _execute_and_persist_cases_async(
+    *,
+    name: str,
+    cases: List[EvalCase],
+    runner: Any,
+    tracer_provider: TracerProvider,
+    max_concurrency: int,
+    api_key: str,
+    base_url: str,
+    throw_on_error: bool,
+    table_id: ResourceId,
+    sheet_id: ResourceId,
+    eval_name: str,
+    by_title: Dict[str, Column],
+    custom_field_titles: List[str],
+) -> Tuple[List[CaseExecution], List[Optional[int]]]:
+    """Async counterpart of :func:`_execute_and_persist_cases_sync`."""
+    total = len(cases)
+    results: List[Optional[CaseExecution]] = [None] * total
+    row_indices: List[Optional[int]] = [None] * total
+    semaphore = asyncio.Semaphore(max(1, max_concurrency))
+    persist_lock = asyncio.Lock()
+
+    async def _run_and_persist(index: int, case: EvalCase) -> Tuple[int, CaseExecution, Optional[int]]:
+        input_value = case["input"]
+        expected_value = case.get("expected")
+        expected_trace_value = case.get("expected_trace")
+        async with semaphore:
+            output_value, trace_id, span_id = await arun_case_in_span(
+                name,
+                runner,
+                input_value,
+                tracer_provider,
+                table_id=table_id,
+                sheet_id=sheet_id,
+            )
+        executed = CaseExecution(
+            input=input_value,
+            expected=expected_value,
+            expected_trace=expected_trace_value,
+            dataset_fields=custom_eval_field_values(case),
+            output=output_value,
+            trace_id=trace_id,
+            span_id=span_id,
+        )
+        async with persist_lock:
+            indices, _rows, updated = await _persist_trace_rows_async(
+                api_key=api_key,
+                base_url=base_url,
+                throw_on_error=throw_on_error,
+                table_id=table_id,
+                sheet_id=sheet_id,
+                eval_name=eval_name,
+                executed=[executed],
+                by_title=by_title,
+                custom_field_titles=custom_field_titles,
+                tracer_provider=tracer_provider,
+            )
+        return index, updated[0], indices[0] if indices else None
+
+    _emit_runners_start(total)
+    completed = 0
+    tasks = [asyncio.create_task(_run_and_persist(index, case)) for index, case in enumerate(cases)]
+    for task in asyncio.as_completed(tasks):
+        index, executed, row_index = await task
+        results[index] = executed
+        row_indices[index] = row_index
+        completed += 1
+        _emit_runner_progress(completed, total)
+
+    return [item for item in results if item is not None], [
+        row_indices[i] for i, item in enumerate(results) if item is not None
+    ]
 
 
 async def _execute_cases_async(
@@ -823,6 +999,14 @@ def _prepare_eval_sync(context: _EvalRunContext) -> _PreparedEval:
         experiment_name=context.experiment_name,
         reuse_default_sheet=context.table_id is None,
     )
+    _emit_dashboard_url(
+        build_table_dashboard_url(
+            api_base_url=context.base_url,
+            workspace_id=table.get("workspace_id"),
+            table_id=table.get("id"),
+            sheet_id=sheet.get("id"),
+        )
+    )
     _emit_status("Loading dataset")
     cases = resolve_cases(context.api_key, context.base_url, context.throw_on_error, context.dataset)
     if not cases:
@@ -893,6 +1077,14 @@ async def _prepare_eval_async(context: _EvalRunContext) -> _PreparedEval:
         sheet_id=None,
         experiment_name=context.experiment_name,
         reuse_default_sheet=context.table_id is None,
+    )
+    _emit_dashboard_url(
+        build_table_dashboard_url(
+            api_base_url=context.base_url,
+            workspace_id=table.get("workspace_id"),
+            table_id=table.get("id"),
+            sheet_id=sheet.get("id"),
+        )
     )
     _emit_status("Loading dataset")
     cases = await aresolve_cases(context.api_key, context.base_url, context.throw_on_error, context.dataset)
@@ -988,7 +1180,6 @@ def _finalize_eval(
         result=result,
         failing_row_indices=failed_indices,
     )
-    _emit_dashboard_url(result.get("url"))
     return result
 
 
@@ -1032,33 +1223,48 @@ def run_eval(
     prepared = _prepare_eval_sync(context)
     table, sheet, columns, cases = prepared.table, prepared.sheet, prepared.columns, prepared.cases
 
-    _emit_status(f"Running cases ({len(cases)} case{'s' if len(cases) != 1 else ''}, concurrency={max_concurrency})")
-    by_title = columns_by_title(columns)
-    executed = _execute_cases_sync(
-        name=name,
-        cases=cases,
-        runner=runner,
-        tracer_provider=tracer_provider,
-        max_concurrency=max_concurrency,
-        table_id=table["id"],
-        sheet_id=sheet["id"],
+    # Tell the open dashboard the planned case count so progress shows "N of 10"
+    # instead of "N of N" while rows are still being written.
+    tables_api.update_sheet(
+        api_key,
+        base_url,
+        throw_on_error,
+        table["id"],
+        sheet["id"],
+        {"expected_row_count": len(cases)},
     )
 
+    _emit_status(f"Running cases ({len(cases)} case{'s' if len(cases) != 1 else ''}, concurrency={max_concurrency})")
+    by_title = columns_by_title(columns)
+
     if context.tracer_provider is not None:
-        _emit_status("Importing traces and writing rows")
-        row_indices, _rows, executed = _persist_trace_rows_sync(
+        # Persist each case as it finishes so the open dashboard sheet fills live
+        # during runners N/M (instead of staying blank until all cases complete).
+        executed, row_indices = _execute_and_persist_cases_sync(
+            name=name,
+            cases=cases,
+            runner=runner,
+            tracer_provider=tracer_provider,
+            max_concurrency=max_concurrency,
             api_key=api_key,
             base_url=base_url,
             throw_on_error=throw_on_error,
             table_id=table["id"],
             sheet_id=sheet["id"],
             eval_name=name,
-            executed=executed,
             by_title=by_title,
             custom_field_titles=prepared.custom_field_titles,
-            tracer_provider=context.tracer_provider,
         )
     else:
+        executed = _execute_cases_sync(
+            name=name,
+            cases=cases,
+            runner=runner,
+            tracer_provider=tracer_provider,
+            max_concurrency=max_concurrency,
+            table_id=table["id"],
+            sheet_id=sheet["id"],
+        )
         _emit_status("Writing rows")
         row_indices, _rows = _persist_batch_rows_sync(
             api_key=api_key,
@@ -1154,33 +1360,46 @@ async def arun_eval(
     prepared = await _prepare_eval_async(context)
     table, sheet, columns, cases = prepared.table, prepared.sheet, prepared.columns, prepared.cases
 
-    _emit_status(f"Running cases ({len(cases)} case{'s' if len(cases) != 1 else ''}, concurrency={max_concurrency})")
-    by_title = columns_by_title(columns)
-    executed = await _execute_cases_async(
-        name=name,
-        cases=cases,
-        runner=runner,
-        tracer_provider=tracer_provider,
-        max_concurrency=max_concurrency,
-        table_id=table["id"],
-        sheet_id=sheet["id"],
+    # Tell the open dashboard the planned case count so progress shows "N of 10"
+    # instead of "N of N" while rows are still being written.
+    await tables_api.aupdate_sheet(
+        api_key,
+        base_url,
+        throw_on_error,
+        table["id"],
+        sheet["id"],
+        {"expected_row_count": len(cases)},
     )
 
+    _emit_status(f"Running cases ({len(cases)} case{'s' if len(cases) != 1 else ''}, concurrency={max_concurrency})")
+    by_title = columns_by_title(columns)
+
     if context.tracer_provider is not None:
-        _emit_status("Importing traces and writing rows")
-        row_indices, _rows, executed = await _persist_trace_rows_async(
+        executed, row_indices = await _execute_and_persist_cases_async(
+            name=name,
+            cases=cases,
+            runner=runner,
+            tracer_provider=tracer_provider,
+            max_concurrency=max_concurrency,
             api_key=api_key,
             base_url=base_url,
             throw_on_error=throw_on_error,
             table_id=table["id"],
             sheet_id=sheet["id"],
             eval_name=name,
-            executed=executed,
             by_title=by_title,
             custom_field_titles=prepared.custom_field_titles,
-            tracer_provider=context.tracer_provider,
         )
     else:
+        executed = await _execute_cases_async(
+            name=name,
+            cases=cases,
+            runner=runner,
+            tracer_provider=tracer_provider,
+            max_concurrency=max_concurrency,
+            table_id=table["id"],
+            sheet_id=sheet["id"],
+        )
         _emit_status("Writing rows")
         row_indices, _rows = await _persist_batch_rows_async(
             api_key=api_key,

--- a/promptlayer/evaluations/runner.py
+++ b/promptlayer/evaluations/runner.py
@@ -1,10 +1,48 @@
 import asyncio
+import json
+import signal
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 from opentelemetry.sdk.trace import TracerProvider
+
+# #region agent log
+_DEBUG_LOG_PATH = "/Users/hasaanmajeed/Documents/promptlayer/prompt-layer-library/.cursor/debug-d605b0.log"
+
+
+def _debug_log(
+    *,
+    hypothesis_id: str,
+    location: str,
+    message: str,
+    data: Optional[Dict[str, Any]] = None,
+    run_id: str = "pre-fix",
+) -> None:
+    try:
+        with open(_DEBUG_LOG_PATH, "a", encoding="utf-8") as log_file:
+            log_file.write(
+                json.dumps(
+                    {
+                        "sessionId": "d605b0",
+                        "runId": run_id,
+                        "hypothesisId": hypothesis_id,
+                        "location": location,
+                        "message": message,
+                        "data": data or {},
+                        "timestamp": int(time.time() * 1000),
+                    }
+                )
+                + "\n"
+            )
+    except Exception:
+        pass
+
+
+# #endregion
 
 from promptlayer.evaluations.polling import (
     afill_row_cells,
@@ -277,6 +315,7 @@ def _execute_and_persist_cases_sync(
     eval_name: str,
     by_title: Dict[str, Column],
     custom_field_titles: List[str],
+    written_counter: Optional[List[int]] = None,
 ) -> Tuple[List[CaseExecution], List[Optional[int]]]:
     """Run cases and write each row as soon as the case finishes.
 
@@ -322,6 +361,8 @@ def _execute_and_persist_cases_sync(
                 custom_field_titles=custom_field_titles,
                 tracer_provider=tracer_provider,
             )
+            if written_counter is not None and indices:
+                written_counter[0] += 1
         return index, updated[0], indices[0] if indices else None
 
     workers = max(1, min(max_concurrency, total or 1))
@@ -377,6 +418,7 @@ async def _execute_and_persist_cases_async(
     eval_name: str,
     by_title: Dict[str, Column],
     custom_field_titles: List[str],
+    written_counter: Optional[List[int]] = None,
 ) -> Tuple[List[CaseExecution], List[Optional[int]]]:
     """Async counterpart of :func:`_execute_and_persist_cases_sync`."""
     total = len(cases)
@@ -420,17 +462,24 @@ async def _execute_and_persist_cases_async(
                 custom_field_titles=custom_field_titles,
                 tracer_provider=tracer_provider,
             )
+            if written_counter is not None and indices:
+                written_counter[0] += 1
         return index, updated[0], indices[0] if indices else None
 
     _emit_runners_start(total)
     completed = 0
     tasks = [asyncio.create_task(_run_and_persist(index, case)) for index, case in enumerate(cases)]
-    for task in asyncio.as_completed(tasks):
-        index, executed, row_index = await task
-        results[index] = executed
-        row_indices[index] = row_index
-        completed += 1
-        _emit_runner_progress(completed, total)
+    try:
+        for task in asyncio.as_completed(tasks):
+            index, executed, row_index = await task
+            results[index] = executed
+            row_indices[index] = row_index
+            completed += 1
+            _emit_runner_progress(completed, total)
+    except (KeyboardInterrupt, asyncio.CancelledError):
+        for task in tasks:
+            task.cancel()
+        raise
 
     return [item for item in results if item is not None], [
         row_indices[i] for i, item in enumerate(results) if item is not None
@@ -1183,6 +1232,189 @@ def _finalize_eval(
     return result
 
 
+def _sheet_row_count_from_payload(payload: Any) -> int:
+    if not isinstance(payload, dict):
+        return 0
+    sheet = payload.get("sheet") if isinstance(payload.get("sheet"), dict) else payload
+    if not isinstance(sheet, dict):
+        return 0
+    raw = sheet.get("row_count")
+    try:
+        return max(0, int(raw))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _publish_eval_run_abort_sync(
+    *,
+    api_key: str,
+    base_url: str,
+    table_id: ResourceId,
+    sheet_id: ResourceId,
+    known_written: int = 0,
+    source: str = "unknown",
+) -> None:
+    """Best-effort: mark populate aborted and align progress after Ctrl+C."""
+    # #region agent log
+    _debug_log(
+        hypothesis_id="B",
+        location="runner.py:_publish_eval_run_abort_sync:entry",
+        message="publish abort called",
+        data={"source": source, "known_written": known_written, "table_id": str(table_id), "sheet_id": str(sheet_id)},
+    )
+    # #endregion
+    written = max(0, int(known_written or 0))
+    try:
+        payload = tables_api.get_sheet(api_key, base_url, False, table_id, sheet_id)
+        written = max(written, _sheet_row_count_from_payload(payload))
+    except Exception as exc:  # noqa: BLE001 - still PATCH abort below
+        # #region agent log
+        _debug_log(
+            hypothesis_id="B",
+            location="runner.py:_publish_eval_run_abort_sync:get_sheet_failed",
+            message="get_sheet failed before abort patch",
+            data={"source": source, "error": type(exc).__name__, "error_msg": str(exc)[:200]},
+        )
+        # #endregion
+        pass
+    try:
+        tables_api.update_sheet(
+            api_key,
+            base_url,
+            False,
+            table_id,
+            sheet_id,
+            {
+                "eval_run_status": "aborted",
+                "expected_row_count": written,
+            },
+        )
+        # #region agent log
+        _debug_log(
+            hypothesis_id="B",
+            location="runner.py:_publish_eval_run_abort_sync:success",
+            message="abort patch succeeded",
+            data={"source": source, "written": written},
+        )
+        # #endregion
+    except Exception as exc:  # noqa: BLE001 - interrupt path must not mask KeyboardInterrupt
+        # #region agent log
+        _debug_log(
+            hypothesis_id="B",
+            location="runner.py:_publish_eval_run_abort_sync:update_failed",
+            message="abort patch failed",
+            data={"source": source, "written": written, "error": type(exc).__name__, "error_msg": str(exc)[:200]},
+        )
+        # #endregion
+        return
+
+
+async def _publish_eval_run_abort_async(
+    *,
+    api_key: str,
+    base_url: str,
+    table_id: ResourceId,
+    sheet_id: ResourceId,
+    known_written: int = 0,
+) -> None:
+    written = max(0, int(known_written or 0))
+    try:
+        payload = await tables_api.aget_sheet(api_key, base_url, False, table_id, sheet_id)
+        written = max(written, _sheet_row_count_from_payload(payload))
+    except Exception:  # noqa: BLE001 - still PATCH abort below
+        pass
+    try:
+        await tables_api.aupdate_sheet(
+            api_key,
+            base_url,
+            False,
+            table_id,
+            sheet_id,
+            {
+                "eval_run_status": "aborted",
+                "expected_row_count": written,
+            },
+        )
+    except Exception:  # noqa: BLE001 - interrupt path must not mask KeyboardInterrupt
+        return
+
+
+@contextmanager
+def _interrupt_eval_run_abort(
+    *,
+    api_key: str,
+    base_url: str,
+    table_id: ResourceId,
+    sheet_id: ResourceId,
+    written_counter: List[int],
+) -> Iterator[None]:
+    """Publish eval_run_status=aborted on SIGINT even if KeyboardInterrupt is delayed."""
+    previous = signal.getsignal(signal.SIGINT)
+    snapped = {"done": False}
+
+    def _handler(signum: int, frame: Any) -> None:
+        # #region agent log
+        _debug_log(
+            hypothesis_id="C",
+            location="runner.py:_interrupt_eval_run_abort:handler",
+            message="SIGINT handler invoked",
+            data={"signum": signum, "already_done": snapped["done"], "written": written_counter[0]},
+        )
+        # #endregion
+        if not snapped["done"]:
+            snapped["done"] = True
+            _publish_eval_run_abort_sync(
+                api_key=api_key,
+                base_url=base_url,
+                table_id=table_id,
+                sheet_id=sheet_id,
+                known_written=written_counter[0],
+                source="sigint_handler",
+            )
+        if callable(previous):
+            previous(signum, frame)
+        else:
+            raise KeyboardInterrupt
+
+    try:
+        signal.signal(signal.SIGINT, _handler)
+        # #region agent log
+        _debug_log(
+            hypothesis_id="C",
+            location="runner.py:_interrupt_eval_run_abort:installed",
+            message="SIGINT handler installed",
+            data={"previous_handler": repr(previous)},
+        )
+        # #endregion
+    except (ValueError, OSError) as exc:
+        # #region agent log
+        _debug_log(
+            hypothesis_id="C",
+            location="runner.py:_interrupt_eval_run_abort:install_failed",
+            message="SIGINT handler install failed",
+            data={"error": type(exc).__name__, "error_msg": str(exc)},
+        )
+        # #endregion
+        yield
+        return
+
+    try:
+        yield
+    finally:
+        # #region agent log
+        _debug_log(
+            hypothesis_id="A",
+            location="runner.py:_interrupt_eval_run_abort:finally",
+            message="SIGINT handler restored; interrupt guard exited",
+            data={"abort_already_published": snapped["done"]},
+        )
+        # #endregion
+        try:
+            signal.signal(signal.SIGINT, previous)
+        except (ValueError, OSError):
+            pass
+
+
 def run_eval(
     *,
     name: str,
@@ -1223,62 +1455,125 @@ def run_eval(
     prepared = _prepare_eval_sync(context)
     table, sheet, columns, cases = prepared.table, prepared.sheet, prepared.columns, prepared.cases
 
-    # Tell the open dashboard the planned case count so progress shows "N of 10"
-    # instead of "N of N" while rows are still being written.
+    # Tell the open dashboard the planned case count + that populate is active.
     tables_api.update_sheet(
         api_key,
         base_url,
         throw_on_error,
         table["id"],
         sheet["id"],
-        {"expected_row_count": len(cases)},
+        {"expected_row_count": len(cases), "eval_run_status": "running"},
     )
 
     _emit_status(f"Running cases ({len(cases)} case{'s' if len(cases) != 1 else ''}, concurrency={max_concurrency})")
     by_title = columns_by_title(columns)
+    written_counter = [0]
 
-    if context.tracer_provider is not None:
-        # Persist each case as it finishes so the open dashboard sheet fills live
-        # during runners N/M (instead of staying blank until all cases complete).
-        executed, row_indices = _execute_and_persist_cases_sync(
-            name=name,
-            cases=cases,
-            runner=runner,
-            tracer_provider=tracer_provider,
-            max_concurrency=max_concurrency,
-            api_key=api_key,
-            base_url=base_url,
-            throw_on_error=throw_on_error,
-            table_id=table["id"],
-            sheet_id=sheet["id"],
-            eval_name=name,
-            by_title=by_title,
-            custom_field_titles=prepared.custom_field_titles,
-        )
-    else:
-        executed = _execute_cases_sync(
-            name=name,
-            cases=cases,
-            runner=runner,
-            tracer_provider=tracer_provider,
-            max_concurrency=max_concurrency,
-            table_id=table["id"],
-            sheet_id=sheet["id"],
-        )
-        _emit_status("Writing rows")
-        row_indices, _rows = _persist_batch_rows_sync(
-            api_key=api_key,
-            base_url=base_url,
-            throw_on_error=throw_on_error,
-            table_id=table["id"],
-            sheet_id=sheet["id"],
-            executed=executed,
-            by_title=by_title,
-            custom_field_titles=prepared.custom_field_titles,
-        )
+    with _interrupt_eval_run_abort(
+        api_key=api_key,
+        base_url=base_url,
+        table_id=table["id"],
+        sheet_id=sheet["id"],
+        written_counter=written_counter,
+    ):
+        try:
+            if context.tracer_provider is not None:
+                # Persist each case as it finishes so the open dashboard sheet fills live
+                # during runners N/M (instead of staying blank until all cases complete).
+                executed, row_indices = _execute_and_persist_cases_sync(
+                    name=name,
+                    cases=cases,
+                    runner=runner,
+                    tracer_provider=tracer_provider,
+                    max_concurrency=max_concurrency,
+                    api_key=api_key,
+                    base_url=base_url,
+                    throw_on_error=throw_on_error,
+                    table_id=table["id"],
+                    sheet_id=sheet["id"],
+                    eval_name=name,
+                    by_title=by_title,
+                    custom_field_titles=prepared.custom_field_titles,
+                    written_counter=written_counter,
+                )
+            else:
+                executed = _execute_cases_sync(
+                    name=name,
+                    cases=cases,
+                    runner=runner,
+                    tracer_provider=tracer_provider,
+                    max_concurrency=max_concurrency,
+                    table_id=table["id"],
+                    sheet_id=sheet["id"],
+                )
+                _emit_status("Writing rows")
+                row_indices, _rows = _persist_batch_rows_sync(
+                    api_key=api_key,
+                    base_url=base_url,
+                    throw_on_error=throw_on_error,
+                    table_id=table["id"],
+                    sheet_id=sheet["id"],
+                    executed=executed,
+                    by_title=by_title,
+                    custom_field_titles=prepared.custom_field_titles,
+                )
+                written_counter[0] = len([index for index in row_indices if index is not None])
+        except KeyboardInterrupt:
+            # #region agent log
+            _debug_log(
+                hypothesis_id="D",
+                location="runner.py:run_eval:keyboard_interrupt",
+                message="KeyboardInterrupt caught in run_eval case phase",
+                data={"written": written_counter[0]},
+            )
+            # #endregion
+            _publish_eval_run_abort_sync(
+                api_key=api_key,
+                base_url=base_url,
+                table_id=table["id"],
+                sheet_id=sheet["id"],
+                known_written=written_counter[0],
+                source="run_eval_except",
+            )
+            raise
+
+    # #region agent log
+    _debug_log(
+        hypothesis_id="A",
+        location="runner.py:run_eval:post_interrupt_context",
+        message="case phase finished; interrupt guard no longer active",
+        data={"written": written_counter[0]},
+    )
+    # #endregion
+
+    # Case writers finished — hand the Running banner off to scorecard/compute.
+    tables_api.update_sheet(
+        api_key,
+        base_url,
+        False,
+        table["id"],
+        sheet["id"],
+        {"eval_run_status": "completed"},
+    )
+    # #region agent log
+    _debug_log(
+        hypothesis_id="E",
+        location="runner.py:run_eval:set_completed",
+        message="eval_run_status set to completed",
+        data={},
+    )
+    # #endregion
 
     processing_ids = _processing_column_ids(columns, context.columns)
     if processing_ids:
+        # #region agent log
+        _debug_log(
+            hypothesis_id="A",
+            location="runner.py:run_eval:preprocessing_start",
+            message="entering preprocessing phase without interrupt guard",
+            data={"processing_ids": processing_ids},
+        )
+        # #endregion
         _emit_status("Computing preprocessing columns")
         wait_for_sheet_operations(
             api_key,
@@ -1360,57 +1655,85 @@ async def arun_eval(
     prepared = await _prepare_eval_async(context)
     table, sheet, columns, cases = prepared.table, prepared.sheet, prepared.columns, prepared.cases
 
-    # Tell the open dashboard the planned case count so progress shows "N of 10"
-    # instead of "N of N" while rows are still being written.
+    # Tell the open dashboard the planned case count + that populate is active.
     await tables_api.aupdate_sheet(
         api_key,
         base_url,
         throw_on_error,
         table["id"],
         sheet["id"],
-        {"expected_row_count": len(cases)},
+        {"expected_row_count": len(cases), "eval_run_status": "running"},
     )
 
     _emit_status(f"Running cases ({len(cases)} case{'s' if len(cases) != 1 else ''}, concurrency={max_concurrency})")
     by_title = columns_by_title(columns)
+    written_counter = [0]
 
-    if context.tracer_provider is not None:
-        executed, row_indices = await _execute_and_persist_cases_async(
-            name=name,
-            cases=cases,
-            runner=runner,
-            tracer_provider=tracer_provider,
-            max_concurrency=max_concurrency,
-            api_key=api_key,
-            base_url=base_url,
-            throw_on_error=throw_on_error,
-            table_id=table["id"],
-            sheet_id=sheet["id"],
-            eval_name=name,
-            by_title=by_title,
-            custom_field_titles=prepared.custom_field_titles,
-        )
-    else:
-        executed = await _execute_cases_async(
-            name=name,
-            cases=cases,
-            runner=runner,
-            tracer_provider=tracer_provider,
-            max_concurrency=max_concurrency,
-            table_id=table["id"],
-            sheet_id=sheet["id"],
-        )
-        _emit_status("Writing rows")
-        row_indices, _rows = await _persist_batch_rows_async(
-            api_key=api_key,
-            base_url=base_url,
-            throw_on_error=throw_on_error,
-            table_id=table["id"],
-            sheet_id=sheet["id"],
-            executed=executed,
-            by_title=by_title,
-            custom_field_titles=prepared.custom_field_titles,
-        )
+    with _interrupt_eval_run_abort(
+        api_key=api_key,
+        base_url=base_url,
+        table_id=table["id"],
+        sheet_id=sheet["id"],
+        written_counter=written_counter,
+    ):
+        try:
+            if context.tracer_provider is not None:
+                executed, row_indices = await _execute_and_persist_cases_async(
+                    name=name,
+                    cases=cases,
+                    runner=runner,
+                    tracer_provider=tracer_provider,
+                    max_concurrency=max_concurrency,
+                    api_key=api_key,
+                    base_url=base_url,
+                    throw_on_error=throw_on_error,
+                    table_id=table["id"],
+                    sheet_id=sheet["id"],
+                    eval_name=name,
+                    by_title=by_title,
+                    custom_field_titles=prepared.custom_field_titles,
+                    written_counter=written_counter,
+                )
+            else:
+                executed = await _execute_cases_async(
+                    name=name,
+                    cases=cases,
+                    runner=runner,
+                    tracer_provider=tracer_provider,
+                    max_concurrency=max_concurrency,
+                    table_id=table["id"],
+                    sheet_id=sheet["id"],
+                )
+                _emit_status("Writing rows")
+                row_indices, _rows = await _persist_batch_rows_async(
+                    api_key=api_key,
+                    base_url=base_url,
+                    throw_on_error=throw_on_error,
+                    table_id=table["id"],
+                    sheet_id=sheet["id"],
+                    executed=executed,
+                    by_title=by_title,
+                    custom_field_titles=prepared.custom_field_titles,
+                )
+                written_counter[0] = len([index for index in row_indices if index is not None])
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            await _publish_eval_run_abort_async(
+                api_key=api_key,
+                base_url=base_url,
+                table_id=table["id"],
+                sheet_id=sheet["id"],
+                known_written=written_counter[0],
+            )
+            raise
+
+    await tables_api.aupdate_sheet(
+        api_key,
+        base_url,
+        False,
+        table["id"],
+        sheet["id"],
+        {"eval_run_status": "completed"},
+    )
 
     processing_ids = _processing_column_ids(columns, context.columns)
     if processing_ids:

--- a/promptlayer/evaluations/runner.py
+++ b/promptlayer/evaluations/runner.py
@@ -1255,38 +1255,52 @@ def _interrupt_eval_run_abort(
     sheet_id: ResourceId,
     written_counter: List[int],
 ) -> Iterator[None]:
-    """Publish eval_run_status=aborted on SIGINT even if KeyboardInterrupt is delayed."""
+    """Publish eval_run_status=aborted on SIGINT or any populate failure.
+
+    Success exits the context normally; callers then PATCH ``completed``.
+    Unexpected exceptions (runner errors, API failures, CancelledError) must
+    clear the dashboard Running banner the same way Ctrl+C does.
+    """
     previous = signal.getsignal(signal.SIGINT)
     snapped = {"done": False}
 
+    def _publish_once() -> None:
+        if snapped["done"]:
+            return
+        snapped["done"] = True
+        _publish_eval_run_abort_sync(
+            api_key=api_key,
+            base_url=base_url,
+            table_id=table_id,
+            sheet_id=sheet_id,
+            known_written=written_counter[0],
+        )
+
     def _handler(signum: int, frame: Any) -> None:
-        if not snapped["done"]:
-            snapped["done"] = True
-            _publish_eval_run_abort_sync(
-                api_key=api_key,
-                base_url=base_url,
-                table_id=table_id,
-                sheet_id=sheet_id,
-                known_written=written_counter[0],
-            )
+        _publish_once()
         if callable(previous):
             previous(signum, frame)
         else:
             raise KeyboardInterrupt
 
+    registered = False
     try:
         signal.signal(signal.SIGINT, _handler)
+        registered = True
     except (ValueError, OSError):
-        yield
-        return
+        pass
 
     try:
         yield
+    except BaseException:
+        _publish_once()
+        raise
     finally:
-        try:
-            signal.signal(signal.SIGINT, previous)
-        except (ValueError, OSError):
-            pass
+        if registered:
+            try:
+                signal.signal(signal.SIGINT, previous)
+            except (ValueError, OSError):
+                pass
 
 
 def run_eval(
@@ -1350,57 +1364,47 @@ def run_eval(
         sheet_id=sheet["id"],
         written_counter=written_counter,
     ):
-        try:
-            if context.tracer_provider is not None:
-                # Persist each case as it finishes so the open dashboard sheet fills live
-                # during runners N/M (instead of staying blank until all cases complete).
-                executed, row_indices = _execute_and_persist_cases_sync(
-                    name=name,
-                    cases=cases,
-                    runner=runner,
-                    tracer_provider=tracer_provider,
-                    max_concurrency=max_concurrency,
-                    api_key=api_key,
-                    base_url=base_url,
-                    throw_on_error=throw_on_error,
-                    table_id=table["id"],
-                    sheet_id=sheet["id"],
-                    eval_name=name,
-                    by_title=by_title,
-                    custom_field_titles=prepared.custom_field_titles,
-                    written_counter=written_counter,
-                )
-            else:
-                executed = _execute_cases_sync(
-                    name=name,
-                    cases=cases,
-                    runner=runner,
-                    tracer_provider=tracer_provider,
-                    max_concurrency=max_concurrency,
-                    table_id=table["id"],
-                    sheet_id=sheet["id"],
-                )
-                _emit_status("Writing rows")
-                row_indices, _rows = _persist_batch_rows_sync(
-                    api_key=api_key,
-                    base_url=base_url,
-                    throw_on_error=throw_on_error,
-                    table_id=table["id"],
-                    sheet_id=sheet["id"],
-                    executed=executed,
-                    by_title=by_title,
-                    custom_field_titles=prepared.custom_field_titles,
-                )
-                written_counter[0] = len([index for index in row_indices if index is not None])
-        except KeyboardInterrupt:
-            _publish_eval_run_abort_sync(
+        if context.tracer_provider is not None:
+            # Persist each case as it finishes so the open dashboard sheet fills live
+            # during runners N/M (instead of staying blank until all cases complete).
+            executed, row_indices = _execute_and_persist_cases_sync(
+                name=name,
+                cases=cases,
+                runner=runner,
+                tracer_provider=tracer_provider,
+                max_concurrency=max_concurrency,
                 api_key=api_key,
                 base_url=base_url,
+                throw_on_error=throw_on_error,
                 table_id=table["id"],
                 sheet_id=sheet["id"],
-                known_written=written_counter[0],
+                eval_name=name,
+                by_title=by_title,
+                custom_field_titles=prepared.custom_field_titles,
+                written_counter=written_counter,
             )
-            raise
+        else:
+            executed = _execute_cases_sync(
+                name=name,
+                cases=cases,
+                runner=runner,
+                tracer_provider=tracer_provider,
+                max_concurrency=max_concurrency,
+                table_id=table["id"],
+                sheet_id=sheet["id"],
+            )
+            _emit_status("Writing rows")
+            row_indices, _rows = _persist_batch_rows_sync(
+                api_key=api_key,
+                base_url=base_url,
+                throw_on_error=throw_on_error,
+                table_id=table["id"],
+                sheet_id=sheet["id"],
+                executed=executed,
+                by_title=by_title,
+                custom_field_titles=prepared.custom_field_titles,
+            )
+            written_counter[0] = len([index for index in row_indices if index is not None])
 
     # Case writers finished — hand the Running banner off to scorecard/compute.
     tables_api.update_sheet(
@@ -1516,55 +1520,45 @@ async def arun_eval(
         sheet_id=sheet["id"],
         written_counter=written_counter,
     ):
-        try:
-            if context.tracer_provider is not None:
-                executed, row_indices = await _execute_and_persist_cases_async(
-                    name=name,
-                    cases=cases,
-                    runner=runner,
-                    tracer_provider=tracer_provider,
-                    max_concurrency=max_concurrency,
-                    api_key=api_key,
-                    base_url=base_url,
-                    throw_on_error=throw_on_error,
-                    table_id=table["id"],
-                    sheet_id=sheet["id"],
-                    eval_name=name,
-                    by_title=by_title,
-                    custom_field_titles=prepared.custom_field_titles,
-                    written_counter=written_counter,
-                )
-            else:
-                executed = await _execute_cases_async(
-                    name=name,
-                    cases=cases,
-                    runner=runner,
-                    tracer_provider=tracer_provider,
-                    max_concurrency=max_concurrency,
-                    table_id=table["id"],
-                    sheet_id=sheet["id"],
-                )
-                _emit_status("Writing rows")
-                row_indices, _rows = await _persist_batch_rows_async(
-                    api_key=api_key,
-                    base_url=base_url,
-                    throw_on_error=throw_on_error,
-                    table_id=table["id"],
-                    sheet_id=sheet["id"],
-                    executed=executed,
-                    by_title=by_title,
-                    custom_field_titles=prepared.custom_field_titles,
-                )
-                written_counter[0] = len([index for index in row_indices if index is not None])
-        except (KeyboardInterrupt, asyncio.CancelledError):
-            await _publish_eval_run_abort_async(
+        if context.tracer_provider is not None:
+            executed, row_indices = await _execute_and_persist_cases_async(
+                name=name,
+                cases=cases,
+                runner=runner,
+                tracer_provider=tracer_provider,
+                max_concurrency=max_concurrency,
                 api_key=api_key,
                 base_url=base_url,
+                throw_on_error=throw_on_error,
                 table_id=table["id"],
                 sheet_id=sheet["id"],
-                known_written=written_counter[0],
+                eval_name=name,
+                by_title=by_title,
+                custom_field_titles=prepared.custom_field_titles,
+                written_counter=written_counter,
             )
-            raise
+        else:
+            executed = await _execute_cases_async(
+                name=name,
+                cases=cases,
+                runner=runner,
+                tracer_provider=tracer_provider,
+                max_concurrency=max_concurrency,
+                table_id=table["id"],
+                sheet_id=sheet["id"],
+            )
+            _emit_status("Writing rows")
+            row_indices, _rows = await _persist_batch_rows_async(
+                api_key=api_key,
+                base_url=base_url,
+                throw_on_error=throw_on_error,
+                table_id=table["id"],
+                sheet_id=sheet["id"],
+                executed=executed,
+                by_title=by_title,
+                custom_field_titles=prepared.custom_field_titles,
+            )
+            written_counter[0] = len([index for index in row_indices if index is not None])
 
     await tables_api.aupdate_sheet(
         api_key,

--- a/promptlayer/integrations/openai_agents/processor.py
+++ b/promptlayer/integrations/openai_agents/processor.py
@@ -189,20 +189,28 @@ class PromptLayerOpenAIAgentsProcessor:
         trace_id_hex: str | None = None,
         span_id_hex: str,
     ):
+        # Prefer the active Eval tracer so agent spans nest under `Eval: …`
+        # (and export on the Eval provider). Always restore id_generator —
+        # leaving FixedIdGenerator(trace_id=None) on the Eval tracer breaks the
+        # next case with "Fixed trace ID was not provided".
         tracer = resolve_tracer(self._tracer_provider.get_tracer("promptlayer.integrations.openai_agents"))
+        previous_id_generator = tracer.id_generator
         tracer.id_generator = _FixedIdGenerator(
             trace_id=hex_id_to_int(trace_id_hex) if trace_id_hex is not None else None,
             span_id=hex_id_to_int(span_id_hex),
         )
-        if context is None and trace_id_hex is not None:
-            context = context_api.Context()
-        return tracer.start_span(
-            name=name,
-            context=context,
-            kind=kind,
-            start_time=start_time,
-            attributes=attributes,
-        )
+        try:
+            if context is None and trace_id_hex is not None:
+                context = context_api.Context()
+            return tracer.start_span(
+                name=name,
+                context=context,
+                kind=kind,
+                start_time=start_time,
+                attributes=attributes,
+            )
+        finally:
+            tracer.id_generator = previous_id_generator
 
 
 def _error_json(payload) -> str:

--- a/promptlayer/span_exporter.py
+++ b/promptlayer/span_exporter.py
@@ -83,6 +83,9 @@ def _mark_genai_request_span(
 class GenAIPromptTemplateSpanProcessor(SpanProcessor):
     """Enrich supported GenAI spans and correlate PromptLayer-managed requests."""
 
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        return True
+
     def on_start(self, span: Any, parent_context: Any = None) -> None:
         try:
             self._on_start(span, parent_context)

--- a/promptlayer/tables/helpers.py
+++ b/promptlayer/tables/helpers.py
@@ -77,7 +77,7 @@ def build_create_sheet_body(body: CreateSheet) -> Dict[str, Any]:
 
 
 def empty_csv_sheet_source(file_name: str = "empty.csv") -> Dict[str, str]:
-    """Minimal file source used to create an empty experiment sheet."""
+    """Minimal file source for callers that explicitly want a CSV-backed sheet create."""
     # Header-only CSV so the import succeeds without seeding eval rows.
     content = base64.b64encode(b"input\n").decode("ascii")
     safe_name = file_name if file_name.endswith((".csv", ".json")) else f"{file_name}.csv"
@@ -89,11 +89,15 @@ def empty_csv_sheet_source(file_name: str = "empty.csv") -> Dict[str, str]:
 
 
 def with_default_empty_sheet_source(body: Optional[CreateSheet] = None) -> CreateSheet:
-    """Ensure a create-sheet body has a source (required by the public API)."""
+    """Return a create-sheet body for an empty sheet (no file/CSV source).
+
+    The public API supports source-less creates. Avoid defaulting to a CSV
+    bootstrap: evals add columns immediately after create, which races the
+    import job and fails with header mismatches.
+    """
     payload: CreateSheet = dict(body or {})  # type: ignore[assignment]
-    if payload.get("source") is None:
-        title = payload.get("title") or "Sheet 1"
-        payload["source"] = empty_csv_sheet_source(f"{title}.csv")  # type: ignore[typeddict-item]
+    if not payload.get("title"):
+        payload["title"] = "Sheet 1"
     return payload
 
 
@@ -102,7 +106,7 @@ def empty_sheet_create_body(title: str) -> CreateSheet:
 
 
 def build_update_sheet_body(body: UpdateSheet) -> Dict[str, Any]:
-    return _defined_fields(body, "title")
+    return _defined_fields(body, "title", "expected_row_count")
 
 
 def build_add_rows_body(body: AddTableRows) -> Dict[str, Any]:

--- a/promptlayer/tables/helpers.py
+++ b/promptlayer/tables/helpers.py
@@ -106,7 +106,7 @@ def empty_sheet_create_body(title: str) -> CreateSheet:
 
 
 def build_update_sheet_body(body: UpdateSheet) -> Dict[str, Any]:
-    return _defined_fields(body, "title", "expected_row_count")
+    return _defined_fields(body, "title", "expected_row_count", "eval_run_status")
 
 
 def build_add_rows_body(body: AddTableRows) -> Dict[str, Any]:

--- a/promptlayer/types/__init__.py
+++ b/promptlayer/types/__init__.py
@@ -1,4 +1,27 @@
 from . import prompt_template, scorecard, skill
+from .prompt_template import (
+    BuiltInTool,
+    LegacyOpenAINativeMcpTool,
+    McpTool,
+    OpenAINativeMcpToolConfig,
+    OpenRouterServerToolConfig,
+    OpenRouterWebSearchToolConfig,
+    PromptTool,
+    ToolVariable,
+)
 from .request_log import RequestLog
 
-__all__ = ["prompt_template", "scorecard", "skill", "RequestLog"]
+__all__ = [
+    "BuiltInTool",
+    "LegacyOpenAINativeMcpTool",
+    "McpTool",
+    "OpenAINativeMcpToolConfig",
+    "OpenRouterServerToolConfig",
+    "OpenRouterWebSearchToolConfig",
+    "PromptTool",
+    "RequestLog",
+    "ToolVariable",
+    "prompt_template",
+    "scorecard",
+    "skill",
+]

--- a/promptlayer/types/prompt_template.py
+++ b/promptlayer/types/prompt_template.py
@@ -10,6 +10,7 @@ class GetPromptTemplate(TypedDict, total=False):
     model: str
     input_variables: Dict[str, Any]
     metadata_filters: Dict[str, str]
+    model_parameter_overrides: Dict[str, Any]
     skip_input_variable_rendering: bool
 
 
@@ -249,8 +250,132 @@ class Tool(TypedDict, total=False):
     function: Function
 
 
+class OpenAIWebSearchToolConfig(TypedDict, total=False):
+    type: Literal["web_search", "web_search_2025_08_26"]
+    filters: Dict[str, Any]
+    search_context_size: Literal["low", "medium", "high"]
+    user_location: Dict[str, Any]
+
+
+class FileSearchToolConfig(TypedDict, total=False):
+    type: Literal["file_search"]
+    vector_store_ids: List[str]
+    filters: Dict[str, Any]
+    max_num_results: int
+    ranking_options: Dict[str, Any]
+
+
+class CodeInterpreterToolConfig(TypedDict, total=False):
+    type: Literal["code_interpreter"]
+    container: Dict[str, Any]
+
+
+class ImageGenerationToolConfig(TypedDict, total=False):
+    type: Literal["image_generation"]
+    action: Literal["generate", "edit", "auto"]
+    background: Literal["transparent", "opaque", "auto"]
+    input_fidelity: Optional[Literal["high", "low"]]
+    input_image_mask: Dict[str, str]
+    model: str
+    moderation: Literal["auto", "low"]
+    output_compression: int
+    output_format: Literal["png", "webp", "jpeg"]
+    partial_images: int
+    quality: Literal["low", "medium", "high", "auto"]
+    size: Literal["1024x1024", "1024x1536", "1536x1024", "auto"]
+
+
+class McpToolApprovalFilter(TypedDict, total=False):
+    tool_names: List[str]
+
+
+class McpToolApproval(TypedDict, total=False):
+    never: McpToolApprovalFilter
+    always: McpToolApprovalFilter
+
+
+class OpenAINativeMcpToolConfig(TypedDict, total=False):
+    type: Literal["mcp"]
+    server_label: str
+    server_url: str
+    server_description: str
+    connector_id: str
+    authorization: str
+    headers: Dict[str, str]
+    allowed_tools: List[str]
+    require_approval: Union[Literal["always", "never"], McpToolApproval]
+
+
+class ShellToolConfig(TypedDict, total=False):
+    type: Literal["shell"]
+    environment: Dict[str, Any]
+
+
+class ApplyPatchToolConfig(TypedDict, total=False):
+    type: Literal["apply_patch"]
+
+
+class OpenRouterWebSearchToolConfig(TypedDict, total=False):
+    id: Literal["web"]
+    engine: Literal["native", "exa", "firecrawl", "parallel", "perplexity"]
+    max_results: int
+    search_prompt: str
+    include_domains: List[str]
+    exclude_domains: List[str]
+
+
+class OpenRouterServerToolConfig(TypedDict, total=False):
+    openrouter_server_tool: str
+    parameters: Dict[str, Any]
+
+
+BuiltInToolConfig = Union[
+    OpenAIWebSearchToolConfig,
+    FileSearchToolConfig,
+    CodeInterpreterToolConfig,
+    ImageGenerationToolConfig,
+    OpenAINativeMcpToolConfig,
+    ShellToolConfig,
+    ApplyPatchToolConfig,
+    OpenRouterWebSearchToolConfig,
+    OpenRouterServerToolConfig,
+    Dict[str, Any],
+]
+
+
 class BuiltInTool(TypedDict, total=False):
+    id: str
     type: str
+    name: str
+    description: str
+    provider: str
+    config: BuiltInToolConfig
+
+
+class McpTool(TypedDict, total=False):
+    type: Literal["mcp"]
+    mcp_server_id: int
+
+
+class LegacyOpenAINativeMcpToolConfig(OpenAINativeMcpToolConfig, total=False):
+    """Legacy OpenAI-native MCP config accepted and normalized by the backend."""
+
+    execution_mode: Literal["provider"]
+
+
+class LegacyOpenAINativeMcpTool(TypedDict, total=False):
+    """Deprecated legacy shape. Use BuiltInTool with type ``openai_mcp``."""
+
+    id: str
+    name: str
+    description: str
+    provider: Literal["openai", "openai.azure"]
+    type: Literal["mcp"]
+    config: LegacyOpenAINativeMcpToolConfig
+
+
+class ToolVariable(TypedDict, total=False):
+    type: Literal["variable"]
     name: str
 
 
@@ -259,6 +384,9 @@ class RegistryTool(TypedDict, total=False):
     tool_registry_id: int
     label: Optional[str]
     version_number: Optional[int]
+
+
+PromptTool = Union[Tool, McpTool, BuiltInTool, LegacyOpenAINativeMcpTool, ToolVariable, RegistryTool]
 
 
 class FunctionCall(TypedDict, total=False):
@@ -364,7 +492,7 @@ class ChatPromptTemplate(TypedDict, total=False):
     functions: Sequence[Function]
     function_call: Union[Literal["auto", "none"], ChatFunctionCall]
     input_variables: List[str]
-    tools: Sequence[Union[Tool, BuiltInTool, RegistryTool]]
+    tools: Sequence[PromptTool]
     tool_choice: ToolChoice
 
 
@@ -394,6 +522,7 @@ class PromptBlueprint(TypedDict, total=False):
 
 class PublishPromptTemplate(BasePromptTemplate, PromptBlueprint, total=False):
     release_labels: Optional[List[str]] = None
+    parent_version_id: int
 
 
 class BaseProviderBaseURL(TypedDict):

--- a/promptlayer/types/table.py
+++ b/promptlayer/types/table.py
@@ -157,6 +157,7 @@ class CreateSheet(TypedDict, total=False):
 
 class UpdateSheet(TypedDict, total=False):
     title: Optional[str]
+    expected_row_count: Optional[int]
 
 
 class ColumnDependency(TypedDict, total=False):

--- a/promptlayer/types/table.py
+++ b/promptlayer/types/table.py
@@ -158,6 +158,7 @@ class CreateSheet(TypedDict, total=False):
 class UpdateSheet(TypedDict, total=False):
     title: Optional[str]
     expected_row_count: Optional[int]
+    eval_run_status: Optional[str]  # running | completed | aborted
 
 
 class ColumnDependency(TypedDict, total=False):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "promptlayer"
-version = "1.5.14"
+version = "1.5.15"
 description = "PromptLayer is a platform for prompt engineering and tracks your LLM requests."
 authors = ["Magniv <hello@magniv.io>"]
 license = "Apache-2.0"

--- a/tests/test_eval_polling.py
+++ b/tests/test_eval_polling.py
@@ -1,9 +1,15 @@
 from contextlib import asynccontextmanager
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from promptlayer import PromptLayerValidationError
+from promptlayer.evaluations.live_progress import (
+    SMART_TABLE_EXECUTION_STATUS_UPDATE,
+    await_sheet_execution_progress,
+    execution_update_to_operation_payload,
+    smart_sheet_channel,
+)
 from promptlayer.evaluations.polling import (
     _status_counts_are_terminal,
     _wait_for_sheet_cells,
@@ -92,15 +98,18 @@ def test_preprocessing_operation_polls_operation_status():
     }
     with (
         patch(
-            "promptlayer.tables.api.create_sheet_operation",
-            return_value={"cell_count": 4, "operation_id": "operation-1", "operation": "recalculate"},
+            "promptlayer.tables.api.acreate_sheet_operation",
+            new=AsyncMock(return_value={"cell_count": 4, "operation_id": "operation-1", "operation": "recalculate"}),
         ),
         patch(
-            "promptlayer.tables.api.get_sheet_operation",
-            # Public API nests status under "operation".
-            return_value={"success": True, "operation": terminal},
+            "promptlayer.evaluations.polling._listen_sheet_operations_live_progress",
+            new=AsyncMock(side_effect=RuntimeError("ws unavailable")),
+        ),
+        patch(
+            "promptlayer.tables.api.aget_sheet_operation",
+            new=AsyncMock(return_value={"success": True, "operation": terminal}),
         ) as get_operation,
-        patch("promptlayer.tables.api.get_sheet_status_counts") as get_counts,
+        patch("promptlayer.tables.api.aget_sheet_status_counts") as get_counts,
     ):
         result = wait_for_sheet_operations(
             "key",
@@ -112,7 +121,7 @@ def test_preprocessing_operation_polls_operation_status():
         )
 
     assert result == terminal
-    get_operation.assert_called_once()
+    get_operation.assert_awaited_once()
     get_counts.assert_not_called()
 
 
@@ -129,11 +138,15 @@ async def test_async_preprocessing_operation_polls_operation_status():
     with (
         patch(
             "promptlayer.tables.api.acreate_sheet_operation",
-            return_value={"cell_count": 4, "operation_id": "operation-1", "operation": "recalculate"},
+            new=AsyncMock(return_value={"cell_count": 4, "operation_id": "operation-1", "operation": "recalculate"}),
+        ),
+        patch(
+            "promptlayer.evaluations.polling._listen_sheet_operations_live_progress",
+            new=AsyncMock(side_effect=RuntimeError("ws unavailable")),
         ),
         patch(
             "promptlayer.tables.api.aget_sheet_operation",
-            return_value={"success": True, "operation": terminal},
+            new=AsyncMock(return_value={"success": True, "operation": terminal}),
         ) as get_operation,
         patch("promptlayer.tables.api.aget_sheet_status_counts") as get_counts,
     ):
@@ -149,6 +162,171 @@ async def test_async_preprocessing_operation_polls_operation_status():
     assert result == terminal
     get_operation.assert_awaited_once()
     get_counts.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_live_progress_advances_cell_progress_for_matching_execution_id():
+    progress = []
+
+    @asynccontextmanager
+    async def fake_client(*_args, **_kwargs):
+        yield object()
+
+    @asynccontextmanager
+    async def fake_subscription(_client, _topic, message_listener):
+        await message_listener(
+            SMART_TABLE_EXECUTION_STATUS_UPDATE,
+            '{"execution_id":"exec-1","status":"running","total":4,"completed":1,"failed":0}',
+        )
+        await message_listener(
+            SMART_TABLE_EXECUTION_STATUS_UPDATE,
+            '{"execution_id":"exec-1","status":"completed","total":4,"completed":4,"failed":0}',
+        )
+        yield
+
+    with (
+        patch(
+            "promptlayer.evaluations.live_progress._get_websocket_token",
+            new=AsyncMock(return_value={"token_details": {"token": "tok"}}),
+        ),
+        patch("promptlayer.evaluations.live_progress.centrifugo_client", side_effect=fake_client),
+        patch("promptlayer.evaluations.live_progress.centrifugo_subscription", side_effect=fake_subscription),
+        patch("promptlayer.evaluations.polling.get_terminal") as terminal,
+    ):
+        terminal.return_value.cell_progress.side_effect = (
+            lambda completed, total, failed=0, status=None: progress.append((completed, total, failed, status))
+        )
+        with (
+            patch(
+                "promptlayer.tables.api.acreate_sheet_operation",
+                new=AsyncMock(return_value={"cell_count": 4, "operation_id": "exec-1", "operation": "recalculate"}),
+            ),
+            patch(
+                "promptlayer.tables.api.aget_sheet_operation",
+                new=AsyncMock(
+                    return_value={
+                        "success": True,
+                        "operation": {
+                            "operation_id": "exec-1",
+                            "status": "completed",
+                            "completed_count": 4,
+                            "failed_count": 0,
+                            "cell_count": 4,
+                        },
+                    }
+                ),
+            ),
+        ):
+            result = await await_for_sheet_operations(
+                "key",
+                "http://localhost:8000",
+                True,
+                "table",
+                "sheet-1",
+                column_ids=["column"],
+            )
+
+    assert result["status"] == "completed"
+    assert progress[0] == (0, 4, 0, None)  # create response reports total only
+    assert (1, 4, 0, "running") in progress
+    assert (4, 4, 0, "completed") in progress
+
+
+@pytest.mark.asyncio
+async def test_live_progress_ignores_unrelated_execution_ids():
+    updates = []
+
+    @asynccontextmanager
+    async def fake_client(*_args, **_kwargs):
+        yield object()
+
+    @asynccontextmanager
+    async def fake_subscription(_client, _topic, message_listener):
+        await message_listener(
+            SMART_TABLE_EXECUTION_STATUS_UPDATE,
+            '{"execution_id":"other-exec","status":"completed","total":9,"completed":9,"failed":0}',
+        )
+        await message_listener(
+            SMART_TABLE_EXECUTION_STATUS_UPDATE,
+            '{"execution_id":"exec-1","status":"completed","total":2,"completed":2,"failed":0}',
+        )
+        yield
+
+    def on_update(payload):
+        updates.append(payload)
+
+    with (
+        patch(
+            "promptlayer.evaluations.live_progress._get_websocket_token",
+            new=AsyncMock(return_value={"token_details": {"token": "tok"}}),
+        ),
+        patch("promptlayer.evaluations.live_progress.centrifugo_client", side_effect=fake_client),
+        patch("promptlayer.evaluations.live_progress.centrifugo_subscription", side_effect=fake_subscription),
+    ):
+        states = await await_sheet_execution_progress(
+            api_key="key",
+            base_url="http://localhost:8000",
+            sheet_id="sheet-1",
+            execution_ids=["exec-1"],
+            on_execution_update=on_update,
+            timeout_seconds=2.0,
+        )
+
+    assert list(states.keys()) == ["exec-1"]
+    assert states["exec-1"]["cell_count"] == 2
+    assert len(updates) == 1
+    assert updates[0]["execution_id"] == "exec-1"
+
+
+@pytest.mark.asyncio
+async def test_live_progress_ws_failure_falls_back_to_rest_polling():
+    terminal = {
+        "operation_id": "operation-1",
+        "status": "completed",
+        "completed_count": 3,
+        "failed_count": 0,
+        "pending_count": 0,
+        "cell_count": 3,
+    }
+    with (
+        patch(
+            "promptlayer.tables.api.acreate_sheet_operation",
+            new=AsyncMock(return_value={"cell_count": 3, "operation_id": "operation-1", "operation": "recalculate"}),
+        ),
+        patch(
+            "promptlayer.evaluations.polling.await_sheet_execution_progress",
+            new=AsyncMock(side_effect=RuntimeError("centrifugo down")),
+        ),
+        patch(
+            "promptlayer.tables.api.aget_sheet_operation",
+            new=AsyncMock(return_value={"success": True, "operation": terminal}),
+        ) as get_operation,
+    ):
+        result = await await_for_sheet_operations(
+            "key",
+            "url",
+            True,
+            "table",
+            "sheet",
+            column_ids=["column"],
+        )
+
+    assert result == terminal
+    get_operation.assert_awaited()
+
+
+def test_smart_sheet_channel_and_payload_mapping():
+    assert smart_sheet_channel("abc") == "smart_sheets:smart_sheet#abc"
+    assert execution_update_to_operation_payload(
+        {"execution_id": "e1", "status": "running", "completed": 2, "failed": 1, "total": 5}
+    ) == {
+        "operation_id": "e1",
+        "execution_id": "e1",
+        "status": "running",
+        "completed_count": 2,
+        "failed_count": 1,
+        "cell_count": 5,
+    }
 
 
 def test_operation_is_terminal_when_cell_counts_finish_without_status():

--- a/tests/test_eval_polling.py
+++ b/tests/test_eval_polling.py
@@ -229,7 +229,8 @@ async def test_live_progress_advances_cell_progress_for_matching_execution_id():
     assert result["status"] == "completed"
     assert progress[0] == (0, 4, 0, None)  # create response reports total only
     assert (1, 4, 0, "running") in progress
-    assert (4, 4, 0, "completed") in progress
+    # Terminal status must be reported once (listener), not again in finalize.
+    assert progress.count((4, 4, 0, "completed")) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_eval_polling.py
+++ b/tests/test_eval_polling.py
@@ -16,7 +16,7 @@ from promptlayer.evaluations.polling import (
     await_for_sheet_operations,
     wait_for_sheet_operations,
 )
-from promptlayer.evaluations.runner import _map_batch_row_indices
+from promptlayer.evaluations.runner import _interrupt_eval_run_abort, _map_batch_row_indices
 from promptlayer.evaluations.scorecard import recalculate_and_wait_scorecard
 from promptlayer.evaluations.tracing import flush_traces, maybe_await
 from promptlayer.tables import api as tables_api
@@ -400,6 +400,39 @@ def test_operation_is_terminal_when_cell_counts_finish_without_status():
             },
         }
     )
+
+
+def test_interrupt_eval_run_abort_publishes_on_populate_failure():
+    with patch("promptlayer.evaluations.runner._publish_eval_run_abort_sync") as publish:
+        with pytest.raises(RuntimeError, match="runner blew up"):
+            with _interrupt_eval_run_abort(
+                api_key="key",
+                base_url="http://localhost:8000",
+                table_id="table",
+                sheet_id="sheet",
+                written_counter=[3],
+            ):
+                raise RuntimeError("runner blew up")
+    publish.assert_called_once_with(
+        api_key="key",
+        base_url="http://localhost:8000",
+        table_id="table",
+        sheet_id="sheet",
+        known_written=3,
+    )
+
+
+def test_interrupt_eval_run_abort_skips_publish_on_success():
+    with patch("promptlayer.evaluations.runner._publish_eval_run_abort_sync") as publish:
+        with _interrupt_eval_run_abort(
+            api_key="key",
+            base_url="http://localhost:8000",
+            table_id="table",
+            sheet_id="sheet",
+            written_counter=[2],
+        ):
+            pass
+    publish.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_eval_polling.py
+++ b/tests/test_eval_polling.py
@@ -370,6 +370,7 @@ def test_smart_sheet_channel_and_payload_mapping():
         "completed_count": 2,
         "failed_count": 1,
         "cell_count": 5,
+        "pending_count": 2,
     }
 
 
@@ -399,6 +400,55 @@ def test_operation_is_terminal_when_cell_counts_finish_without_status():
             },
         }
     )
+
+
+@pytest.mark.asyncio
+async def test_live_progress_completes_when_safety_poll_counts_finish_with_stale_status():
+    """Safety poll must finish the wait when counts are done even if status lags."""
+    updates = []
+
+    @asynccontextmanager
+    async def fake_client(*_args, **_kwargs):
+        yield object()
+
+    @asynccontextmanager
+    async def fake_subscription(_client, _topic, _message_listener):
+        yield
+
+    async def safety_poll():
+        return {
+            "exec-1": {
+                "operation_id": "exec-1",
+                "status": "running",
+                "pending_count": 0,
+                "completed_count": 4,
+                "failed_count": 0,
+                "cell_count": 4,
+            }
+        }
+
+    with (
+        patch(
+            "promptlayer.evaluations.live_progress._get_websocket_token",
+            new=AsyncMock(return_value={"token_details": {"token": "tok"}}),
+        ),
+        patch("promptlayer.evaluations.live_progress.centrifugo_client", side_effect=fake_client),
+        patch("promptlayer.evaluations.live_progress.centrifugo_subscription", side_effect=fake_subscription),
+    ):
+        states = await await_sheet_execution_progress(
+            api_key="key",
+            base_url="http://localhost:8000",
+            sheet_id="sheet-1",
+            execution_ids=["exec-1"],
+            on_execution_update=updates.append,
+            safety_poll=safety_poll,
+            safety_poll_interval_seconds=0.01,
+            timeout_seconds=2.0,
+        )
+
+    assert states["exec-1"]["completed_count"] == 4
+    assert updates
+    assert updates[-1]["status"] == "running"
 
 
 def test_scorecard_polling_waits_for_terminal_calculation():

--- a/tests/test_eval_polling.py
+++ b/tests/test_eval_polling.py
@@ -125,6 +125,49 @@ def test_preprocessing_operation_polls_operation_status():
     get_counts.assert_not_called()
 
 
+def test_wait_for_sheet_operations_works_inside_running_event_loop():
+    """Sync wait wraps asyncio.run; Jupyter-style nested loops need nest_asyncio."""
+    terminal = {
+        "operation_id": "operation-1",
+        "status": "completed",
+        "completed_count": 4,
+        "failed_count": 0,
+        "pending_count": 0,
+        "cell_count": 4,
+    }
+
+    async def call_from_running_loop():
+        with (
+            patch(
+                "promptlayer.tables.api.acreate_sheet_operation",
+                new=AsyncMock(
+                    return_value={"cell_count": 4, "operation_id": "operation-1", "operation": "recalculate"}
+                ),
+            ),
+            patch(
+                "promptlayer.evaluations.polling._listen_sheet_operations_live_progress",
+                new=AsyncMock(side_effect=RuntimeError("ws unavailable")),
+            ),
+            patch(
+                "promptlayer.tables.api.aget_sheet_operation",
+                new=AsyncMock(return_value={"success": True, "operation": terminal}),
+            ),
+        ):
+            return wait_for_sheet_operations(
+                "key",
+                "url",
+                True,
+                "table",
+                "sheet",
+                column_ids=["column"],
+            )
+
+    import asyncio
+
+    result = asyncio.run(call_from_running_loop())
+    assert result == terminal
+
+
 @pytest.mark.asyncio
 async def test_async_preprocessing_operation_polls_operation_status():
     terminal = {

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -866,8 +866,8 @@ def test_eval_runs_inline_dataset_and_writes_rows(
 @patch("promptlayer.tables.api.create_sheet")
 @patch("promptlayer.tables.api.list_smart_sheet_columns")
 @patch("promptlayer.tables.api.create_sheet_column")
-@patch("promptlayer.tables.api.create_sheet_operation")
-@patch("promptlayer.tables.api.get_sheet_operation")
+@patch("promptlayer.tables.api.acreate_sheet_operation")
+@patch("promptlayer.tables.api.aget_sheet_operation")
 @patch("promptlayer.tables.api.configure_sheet_scorecard")
 @patch("promptlayer.tables.api.add_smart_sheet_rows")
 @patch("promptlayer.tables.api.list_smart_sheet_rows")
@@ -1007,11 +1007,11 @@ def test_eval_creates_supporting_columns_and_runs_operations_before_scorecard(
     ]
     assert not any(call[0][5].get("type") == "CODE_EXECUTION" for call in mock_create_column.call_args_list)
 
-    mock_create_operation.assert_called_once()
-    operation_body = mock_create_operation.call_args[0][5]
+    mock_create_operation.assert_awaited_once()
+    operation_body = mock_create_operation.await_args[0][5]
     assert operation_body["column_ids"] == ["c-extract"]
     assert operation_body["row_ids"] == [0]
-    mock_get_operation.assert_called()
+    mock_get_operation.assert_awaited()
 
     scorecard_body = mock_configure_scorecard.call_args[0][5]
     assert scorecard_body["steps"][0]["title"] == "has_name"

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -58,6 +58,15 @@ def _terminal_sheet_status_counts():
         patch("promptlayer.tables.api.aget_sheet_status_counts", return_value=terminal),
         patch("promptlayer.tables.api.add_trace_import", side_effect=trace_import),
         patch("promptlayer.tables.api.aadd_trace_import", new_callable=AsyncMock, side_effect=atrace_import),
+        patch(
+            "promptlayer.tables.api.update_sheet",
+            return_value={"sheet": {"id": "sheet-1", "title": "Experiment #1"}},
+        ),
+        patch(
+            "promptlayer.tables.api.aupdate_sheet",
+            new_callable=AsyncMock,
+            return_value={"sheet": {"id": "sheet-1", "title": "Experiment #1"}},
+        ),
         patch("opentelemetry.sdk.trace.export.BatchSpanProcessor.on_end"),
         patch("promptlayer.evaluations.runner.wait_for_trace_request_price"),
         patch(

--- a/tests/test_openai_agents_integration.py
+++ b/tests/test_openai_agents_integration.py
@@ -386,6 +386,35 @@ def test_openai_agents_trace_nests_under_eval_span(in_memory_tracer_provider):
     agent_provider.shutdown()
 
 
+def test_openai_agents_under_shared_provider_allows_second_eval_case(in_memory_tracer_provider):
+    """Regression: FixedIdGenerator must not stick on the Eval tracer mid-run."""
+    provider, exporter = in_memory_tracer_provider
+    processor = PromptLayerOpenAIAgentsProcessor(tracer_provider=provider)
+    set_trace_processors([processor])
+
+    def runner(case_input):
+        with trace(f"workflow-{case_input}", trace_id="trace_" + ("e" * 32)):
+            with generation_span(
+                input=[{"role": "user", "content": case_input}],
+                output=[{"role": "assistant", "content": "ok"}],
+                model="gpt-4.1",
+            ):
+                pass
+        return "ok"
+
+    first = run_case_in_span("case-1", runner, "a", provider)
+    # Previously failed here: Eval tracer.id_generator was left as FixedIdGenerator(trace_id=None).
+    second = run_case_in_span("case-2", runner, "b", provider)
+
+    assert first[0] == "ok"
+    assert second[0] == "ok"
+    assert first[1] != second[1]
+
+    spans = _finished_spans(exporter)
+    eval_names = {span.name for span in spans if span.name.startswith("Eval:")}
+    assert eval_names == {"Eval: case-1", "Eval: case-2"}
+
+
 def test_create_openai_agents_tracer_provider_targets_public_v1_traces(monkeypatch):
     seen = {}
 

--- a/tests/test_prompt_template_tools.py
+++ b/tests/test_prompt_template_tools.py
@@ -1,0 +1,140 @@
+from copy import deepcopy
+from unittest.mock import MagicMock, patch
+
+from promptlayer.template_cache import is_locally_renderable, render_response
+from promptlayer.types import (
+    BuiltInTool,
+    LegacyOpenAINativeMcpTool,
+    McpTool,
+    OpenRouterWebSearchToolConfig,
+    PromptTool,
+    ToolVariable,
+)
+from promptlayer.types.prompt_template import PublishPromptTemplate
+from promptlayer.utils import get_prompt_template, publish_prompt_template
+
+
+def _prompt_tools() -> list[PromptTool]:
+    managed_mcp: McpTool = {"type": "mcp", "mcp_server_id": 42}
+    native_mcp: BuiltInTool = {
+        "id": "openai_mcp",
+        "name": "MCP",
+        "description": "OpenAI-native MCP",
+        "provider": "openai",
+        "type": "openai_mcp",
+        "config": {
+            "type": "mcp",
+            "server_label": "docs",
+            "server_url": "https://docs.example.com/mcp",
+            "headers": {"Authorization": "Bearer token"},
+            "require_approval": "never",
+        },
+    }
+    tool_variable: ToolVariable = {"type": "variable", "name": "additional_tools"}
+    openrouter_config: OpenRouterWebSearchToolConfig = {
+        "id": "web",
+        "engine": "exa",
+        "max_results": 3,
+    }
+    openrouter_tool: BuiltInTool = {
+        "id": "openrouter_web",
+        "name": "Web Search",
+        "description": "OpenRouter web search",
+        "provider": "openrouter",
+        "type": "web_search",
+        "config": openrouter_config,
+    }
+    return [managed_mcp, native_mcp, tool_variable, openrouter_tool]
+
+
+def test_publish_prompt_template_preserves_new_tool_shapes():
+    tools = _prompt_tools()
+    body: PublishPromptTemplate = {
+        "prompt_name": "mcp-prompt",
+        "prompt_template": {
+            "type": "chat",
+            "messages": [{"role": "user", "content": [{"type": "text", "text": "Search"}]}],
+            "tools": tools,
+        },
+        "metadata": {
+            "model": {
+                "provider": "openai",
+                "name": "gpt-5",
+                "parameters": {},
+            }
+        },
+        "parent_version_id": 7,
+    }
+    mock_response = MagicMock(status_code=201)
+    mock_response.json.return_value = {"success": True}
+
+    with patch("promptlayer.utils._get_requests_session") as mock_session:
+        mock_session.return_value.post.return_value = mock_response
+        publish_prompt_template("test-key", "https://api.promptlayer.com", True, body)
+
+    payload = mock_session.return_value.post.call_args.kwargs["json"]
+    assert payload["prompt_version"]["prompt_template"]["tools"] == tools
+    assert payload["prompt_version"]["parent_version_id"] == 7
+
+
+def test_get_prompt_template_preserves_managed_mcp_and_resolved_kwargs():
+    response_body = {
+        "prompt_template": {
+            "type": "chat",
+            "messages": [],
+            "tools": [{"type": "mcp", "mcp_server_id": 42}],
+        },
+        "llm_kwargs": {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "search_docs",
+                        "description": "Search documentation",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ]
+        },
+    }
+    mock_response = MagicMock(status_code=200)
+    mock_response.json.return_value = response_body
+
+    with patch("promptlayer.utils._get_requests_session") as mock_session:
+        mock_session.return_value.post.return_value = mock_response
+        result = get_prompt_template("test-key", "https://api.promptlayer.com", True, "mcp-prompt")
+
+    assert result == response_body
+
+
+def test_mcp_prompt_cache_rendering_preserves_resolved_kwargs():
+    response = {
+        "prompt_template": {
+            "type": "chat",
+            "messages": [{"role": "user", "content": [{"type": "text", "text": "Search"}]}],
+            "tools": [{"type": "mcp", "mcp_server_id": 42}],
+        },
+        "llm_kwargs": {"tools": [{"type": "function", "function": {"name": "search_docs"}}]},
+    }
+    expected_kwargs = deepcopy(response["llm_kwargs"])
+
+    assert is_locally_renderable(response)
+    assert render_response(response)["llm_kwargs"] == expected_kwargs
+
+
+def test_legacy_openai_native_mcp_type_remains_available():
+    legacy_tool: LegacyOpenAINativeMcpTool = {
+        "id": "openai_mcp",
+        "name": "MCP",
+        "description": "Legacy OpenAI-native MCP",
+        "provider": "openai",
+        "type": "mcp",
+        "config": {
+            "type": "mcp",
+            "server_label": "docs",
+            "server_url": "https://docs.example.com/mcp",
+            "execution_mode": "provider",
+        },
+    }
+
+    assert legacy_tool["config"]["execution_mode"] == "provider"


### PR DESCRIPTION
## Summary
Make Eval SDK sheet operation wait for WebSocket-first so CLI `cell_progress` tracks the dashboard 1:1 via `SMART_TABLE_EXECUTION_STATUS_UPDATE`, with REST as fallback. Also wire Eval populate lifecycle (`eval_run_status` / `expected_row_count`) so the dashboard Running banner and N-of-M progress stay accurate through live fills, Ctrl+C abort, and nest_asyncio-safe sync waits.

## Changes
- Add `evaluations/live_progress.py` Centrifugo listener for sheet execution-status updates (filter by operation `execution_id`s)
- Wire `wait_for_sheet_operations` / `await_for_sheet_operations` to WS-first progress; sync path runs async under the hood via `_run_coro_sync` + `nest_asyncio` (Jupyter-safe)
- Keep light REST safety poll; fall back to REST if WS token/connect/subscribe fails
- Treat operations as terminal when cell counts finish even if Redis status lags (`operation_payload_is_terminal` shared by WS + REST)
- Support optional `statuses` on wait helpers (`None` = STALE-only API default; `[]` = force all cells)
- Publish sheet `expected_row_count` + `eval_run_status` (`running` → `completed` / `aborted` on Ctrl+C) so the dashboard can show live N of M and Stopped
- Incremental run+persist so rows appear during `runners N/M` instead of only after a batch import
- On abort, PATCH `eval_run_status: aborted` without snapping `expected_row_count` (keep planned denominator, e.g. 3 of 10)
- Add SDK tests for matching IDs, ignored foreign IDs, REST fallback, count-based terminal detection, and abort expected-count behavior
- Updated PromptBlueprint Types 

## Test plan
- [x] Tested locally
- [x] Added/updated tests
- [ ] Verified in staging
- [x] `poetry run pytest tests/test_eval_polling.py`
- [x] Manual: `sample-promptlayer-python/recalc_traces_download.py` with `statuses=[]` → live `cells N/M` aligned with UI
- [x] Manual: eval Ctrl+C mid-run → dashboard Stopped with written of planned (not snapped N of N)

## Checklist
- [x] Code follows project conventions
- [x] No `any` types in TypeScript (frontend)
- [x] Tests pass locally
- [ ] Documentation updated if needed
- [ ] Update `promptlayer-helm` if you add a new envvar (env/ is tied to Cloud Run only and will be removed soon)