### PR TITLE
Stamp the opening user message as input.value on OpenAI Agents trace

### DIFF
--- a/promptlayer/__init__.py
+++ b/promptlayer/__init__.py
@@ -36,7 +36,7 @@ from .exceptions import (
 from .promptlayer import AsyncPromptLayer, PromptLayer
 from .tracing import NATIVE_OTEL_PROVIDERS, configure_tracing, instrument_openai
 
-__version__ = "1.5.15"
+__version__ = "1.5.16"
 __all__ = [
     "PromptLayer",
     "AsyncPromptLayer",

--- a/promptlayer/evaluations/live_progress.py
+++ b/promptlayer/evaluations/live_progress.py
@@ -31,25 +31,32 @@ def smart_sheet_channel(sheet_id: Any) -> str:
 
 
 def execution_update_to_operation_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
-    """Map WS execution status fields onto the public operation status shape."""
+    """Map WS execution status fields onto the public operation status shape.
+
+    Only copy counters that are present on the event. Status-only updates must not
+    invent ``completed/failed/total = 0``, or count-based terminal detection can
+    treat ``0 + 0 >= 0`` as done while the operation is still ``running``.
+    """
     execution_id = str(payload.get("execution_id") or "")
-    completed = payload.get("completed", 0)
-    failed = payload.get("failed", 0)
-    total = payload.get("total", 0)
-    mapped = {
+    mapped: Dict[str, Any] = {
         "operation_id": execution_id,
         "execution_id": execution_id,
         "status": payload.get("status"),
-        "completed_count": completed,
-        "failed_count": failed,
-        "cell_count": total,
     }
-    # Derive pending when the WS event omits it so count-based terminal
-    # detection matches REST safety-poll payloads.
+    if "completed" in payload:
+        mapped["completed_count"] = payload["completed"]
+    if "failed" in payload:
+        mapped["failed_count"] = payload["failed"]
+    if "total" in payload:
+        mapped["cell_count"] = payload["total"]
+    # Derive pending only when all three counters are present so count-based
+    # terminal detection matches REST safety-poll payloads.
+    if not all(key in mapped for key in ("completed_count", "failed_count", "cell_count")):
+        return mapped
     try:
-        completed_n = int(completed)
-        failed_n = int(failed)
-        total_n = int(total)
+        completed_n = int(mapped["completed_count"])
+        failed_n = int(mapped["failed_count"])
+        total_n = int(mapped["cell_count"])
     except (TypeError, ValueError):
         return mapped
     if completed_n >= 0 and failed_n >= 0 and total_n >= 0:
@@ -102,7 +109,9 @@ def operation_payload_is_terminal(payload: Optional[Dict[str, Any]]) -> bool:
     """True when status is terminal, or when cell counts show the operation finished.
 
     Matches REST polling: Redis status can lag behind finished cells, so treat
-    ``pending_count == 0`` and ``completed + failed >= cell_count`` as done.
+    ``pending_count == 0`` and ``completed + failed >= cell_count`` as done when
+    ``cell_count > 0``. A zero/missing total alone must not end the wait (status-only
+    WS events used to invent zeros and falsely trip this path).
     """
     payload = _normalize_operation_status_payload(payload)
     if not isinstance(payload, dict):
@@ -116,7 +125,7 @@ def operation_payload_is_terminal(payload: Optional[Dict[str, Any]]) -> bool:
     cell_count = _non_negative_int(payload.get("cell_count"))
     if pending is None or completed is None or failed is None or cell_count is None:
         return False
-    if pending > 0:
+    if pending > 0 or cell_count == 0:
         return False
     return completed + failed >= cell_count
 

--- a/promptlayer/integrations/claude_agents/vendor/trace/.claude-plugin/plugin.json
+++ b/promptlayer/integrations/claude_agents/vendor/trace/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "trace",
   "description": "Automatically trace Claude Code conversations to PromptLayer. Captures user messages, assistant responses, and tool calls as structured spans.",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": {
     "name": "PromptLayer"
   }

--- a/promptlayer/integrations/claude_agents/vendor/trace/.claude-plugin/plugin.json
+++ b/promptlayer/integrations/claude_agents/vendor/trace/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "trace",
   "description": "Automatically trace Claude Code conversations to PromptLayer. Captures user messages, assistant responses, and tool calls as structured spans.",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "author": {
     "name": "PromptLayer"
   }

--- a/promptlayer/integrations/claude_agents/vendor/trace/hooks/lib.sh
+++ b/promptlayer/integrations/claude_agents/vendor/trace/hooks/lib.sh
@@ -15,7 +15,7 @@ export PL_OTLP_ENDPOINT="${PROMPTLAYER_OTLP_ENDPOINT:-https://api.promptlayer.co
 export PL_QUEUE_DRAIN_LIMIT="${PROMPTLAYER_QUEUE_DRAIN_LIMIT:-10}"
 export PL_OTLP_CONNECT_TIMEOUT="${PROMPTLAYER_OTLP_CONNECT_TIMEOUT:-5}"
 export PL_OTLP_MAX_TIME="${PROMPTLAYER_OTLP_MAX_TIME:-12}"
-export PL_PLUGIN_VERSION="1.0.0"
+export PL_PLUGIN_VERSION="1.1.1"
 PL_CC_VERSION="$(claude --version 2>/dev/null || echo 'unknown')"
 export PL_CC_VERSION
 export PL_USER_AGENT="promptlayer-claude-plugin/${PL_PLUGIN_VERSION} claude-code/${PL_CC_VERSION}"

--- a/promptlayer/integrations/claude_agents/vendor/trace/hooks/lib.sh
+++ b/promptlayer/integrations/claude_agents/vendor/trace/hooks/lib.sh
@@ -15,7 +15,7 @@ export PL_OTLP_ENDPOINT="${PROMPTLAYER_OTLP_ENDPOINT:-https://api.promptlayer.co
 export PL_QUEUE_DRAIN_LIMIT="${PROMPTLAYER_QUEUE_DRAIN_LIMIT:-10}"
 export PL_OTLP_CONNECT_TIMEOUT="${PROMPTLAYER_OTLP_CONNECT_TIMEOUT:-5}"
 export PL_OTLP_MAX_TIME="${PROMPTLAYER_OTLP_MAX_TIME:-12}"
-export PL_PLUGIN_VERSION="1.1.1"
+export PL_PLUGIN_VERSION="1.1.2"
 PL_CC_VERSION="$(claude --version 2>/dev/null || echo 'unknown')"
 export PL_CC_VERSION
 export PL_USER_AGENT="promptlayer-claude-plugin/${PL_PLUGIN_VERSION} claude-code/${PL_CC_VERSION}"

--- a/promptlayer/integrations/claude_agents/vendor/trace/hooks/py/context.py
+++ b/promptlayer/integrations/claude_agents/vendor/trace/hooks/py/context.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 
 
-PLUGIN_VERSION = "1.1.1"
+PLUGIN_VERSION = "1.1.2"
 
 
 def env_int(name: str, default: int) -> int:

--- a/promptlayer/integrations/claude_agents/vendor/trace/hooks/py/context.py
+++ b/promptlayer/integrations/claude_agents/vendor/trace/hooks/py/context.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 
 
-PLUGIN_VERSION = "1.0.0"
+PLUGIN_VERSION = "1.1.1"
 
 
 def env_int(name: str, default: int) -> int:

--- a/promptlayer/integrations/claude_agents/vendor/trace/hooks/py/handlers.py
+++ b/promptlayer/integrations/claude_agents/vendor/trace/hooks/py/handlers.py
@@ -225,14 +225,16 @@ def handle_stop_hook(ctx, raw_input: str) -> str:
 
     if not state.session_input:
         turn_input = session_input_from_parsed(parsed)
-        if turn_input and acquire_lock(lock_path):
-            try:
-                state, path = load_session_state(ctx.session_state_dir, str(session_id))
-                if not state.session_input:
-                    state.session_input = turn_input
-                    save_session_state(path, state)
-            finally:
-                release_lock(lock_path)
+        if turn_input:
+            state.session_input = turn_input
+            if acquire_lock(lock_path):
+                try:
+                    persisted, path = load_session_state(ctx.session_state_dir, str(session_id))
+                    if persisted.trace_id and not persisted.session_input:
+                        persisted.session_input = turn_input
+                        save_session_state(path, persisted)
+                finally:
+                    release_lock(lock_path)
 
     span_specs = build_stop_hook_span_specs(
         parsed=parsed,

--- a/promptlayer/integrations/claude_agents/vendor/trace/hooks/py/handlers.py
+++ b/promptlayer/integrations/claude_agents/vendor/trace/hooks/py/handlers.py
@@ -21,7 +21,7 @@ from state import (
     save_session_state,
     session_lock_path,
 )
-from stop_parser import build_stop_hook_span_specs, parse_transcript
+from stop_parser import build_stop_hook_span_specs, parse_transcript, session_input_attrs, session_input_from_parsed
 from traceparent import parse_traceparent
 
 
@@ -148,15 +148,16 @@ def handle_session_end(ctx, raw_input: str) -> str:
                 trace_id=state.trace_id,
                 span_id=state.session_span_id,
                 parent_span_id=state.session_parent_span_id,
-                name="LLM Session",
+                name="Claude Code session",
                 kind="1",
                 start_ns=state.session_start_ns or str(time.time_ns()),
                 end_ns=str(time.time_ns()),
                 attrs={
                     "source": "claude-code",
                     "hook": "SessionEnd",
-                    "node_type": "LLM_SESSION",
+                    "node_type": "WORKFLOW",
                     "session.lifecycle": "complete",
+                    **session_input_attrs(state.session_input),
                 },
             )
         )
@@ -222,6 +223,17 @@ def handle_stop_hook(ctx, raw_input: str) -> str:
         attempts += 1
         time.sleep(0.2)
 
+    if not state.session_input:
+        turn_input = session_input_from_parsed(parsed)
+        if turn_input and acquire_lock(lock_path):
+            try:
+                state, path = load_session_state(ctx.session_state_dir, str(session_id))
+                if not state.session_input:
+                    state.session_input = turn_input
+                    save_session_state(path, state)
+            finally:
+                release_lock(lock_path)
+
     span_specs = build_stop_hook_span_specs(
         parsed=parsed,
         trace_id=state.trace_id,
@@ -230,6 +242,7 @@ def handle_stop_hook(ctx, raw_input: str) -> str:
         session_start_ns=state.session_start_ns or str(time.time_ns()),
         session_init_source=state.session_init_source,
         generate_span_id=generate_span_id,
+        session_input=state.session_input,
     )
     spans = [build_span(span_spec) for span_spec in span_specs]
     if spans:

--- a/promptlayer/integrations/claude_agents/vendor/trace/hooks/py/state.py
+++ b/promptlayer/integrations/claude_agents/vendor/trace/hooks/py/state.py
@@ -19,6 +19,7 @@ class SessionState:
     session_traceparent_version: str = ""
     session_trace_flags: str = ""
     trace_context_source: str = ""
+    session_input: str = ""
 
     @classmethod
     def from_dict(cls, data):

--- a/promptlayer/integrations/claude_agents/vendor/trace/hooks/py/stop_parser.py
+++ b/promptlayer/integrations/claude_agents/vendor/trace/hooks/py/stop_parser.py
@@ -68,6 +68,22 @@ def message_text(content):
     return ""
 
 
+def message_thinking(content):
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "thinking":
+                thinking = block.get("thinking")
+                if isinstance(thinking, str) and thinking:
+                    parts.append(thinking)
+        return "\n".join(parts).strip()
+    if isinstance(content, dict) and content.get("type") == "thinking":
+        thinking = content.get("thinking")
+        if isinstance(thinking, str):
+            return thinking
+    return ""
+
+
 def flatten_indexed(prefix, items, out):
     for i, item in enumerate(items):
         for key, value in item.items():
@@ -125,6 +141,9 @@ def merge_content_blocks(existing, incoming):
 
 
 def coalesce_assistant_message_fragments(records):
+    """Claude Code writes one API reply as several consecutive transcript records (one per content
+    block) that share message.id and repeat the same usage. Merge them back into one record so a
+    reply becomes one LLM span with its usage counted once."""
     coalesced = []
     for rec in records:
         if not coalesced:
@@ -181,11 +200,11 @@ def parse_transcript(transcript_path, turn_start_fallback, pending_payloads, exp
             except Exception:
                 continue
 
-    records = coalesce_assistant_message_fragments(records)
-
     if not records:
         now_ns = int(datetime.now(timezone.utc).timestamp() * 1_000_000_000)
         return {"turn": {"start_ns": now_ns, "end_ns": now_ns}, "tools": [], "llms": []}
+
+    records = coalesce_assistant_message_fragments(records)
 
     turn_start_idx = 0
     for i in range(len(records) - 1, -1, -1):
@@ -202,6 +221,7 @@ def parse_transcript(transcript_path, turn_start_fallback, pending_payloads, exp
     llms = []
     pending_tool_uses = []
     pending_payload_idx = 0
+    saw_human_input = False
 
     turn_start_ns = turn_start_fallback
     turn_end_ns = turn_start_fallback
@@ -224,6 +244,7 @@ def parse_transcript(transcript_path, turn_start_fallback, pending_payloads, exp
                 if content:
                     append_history_item(history, {"role": "user", "content": content})
                     last_input_ns = timestamp_ns or last_input_ns
+                    saw_human_input = True
             continue
 
         if rec_type == "user":
@@ -294,6 +315,7 @@ def parse_transcript(transcript_path, turn_start_fallback, pending_payloads, exp
             user_text = content_to_text(content)
             append_history_item(history, {"role": "user", "content": user_text})
             last_input_ns = timestamp_ns or last_input_ns
+            saw_human_input = True
             continue
 
         if rec_type != "assistant":
@@ -310,6 +332,7 @@ def parse_transcript(transcript_path, turn_start_fallback, pending_payloads, exp
         prompt_tokens = safe_int(usage.get("input_tokens"), 0)
         completion_tokens = safe_int(usage.get("output_tokens"), 0)
         output_text = message_text(msg.get("content"))
+        output_thinking = message_thinking(msg.get("content"))
 
         tool_calls = []
         content_blocks = msg.get("content")
@@ -339,7 +362,7 @@ def parse_transcript(transcript_path, turn_start_fallback, pending_payloads, exp
                     }
                 )
 
-        if not output_text and not tool_calls:
+        if not output_text and not output_thinking and not tool_calls:
             continue
 
         llm_start_ns = last_input_ns or timestamp_ns or turn_start_ns
@@ -371,11 +394,13 @@ def parse_transcript(transcript_path, turn_start_fallback, pending_payloads, exp
         flatten_indexed("gen_ai.prompt", history, attrs)
 
         completion_item = {"role": "assistant", "content": output_text}
+        if output_thinking:
+            completion_item["thinking"] = output_thinking
         if tool_calls:
             completion_item["tool_calls"] = tool_calls
         flatten_indexed("gen_ai.completion", [completion_item], attrs)
 
-        span_name = "LLM call"
+        span_name = "LLM Call (User)" if saw_human_input else "LLM call"
 
         if emit_for_turn:
             llms.append(
@@ -388,9 +413,12 @@ def parse_transcript(transcript_path, turn_start_fallback, pending_payloads, exp
             )
 
         assistant_history = {"role": "assistant", "content": output_text}
+        if output_thinking:
+            assistant_history["thinking"] = output_thinking
         if tool_calls:
             assistant_history["tool_calls"] = tool_calls
         history.append(assistant_history)
+        saw_human_input = False
 
     if turn_start_ns is None:
         turn_start_ns = int(datetime.now(timezone.utc).timestamp() * 1_000_000_000)
@@ -404,6 +432,28 @@ def parse_transcript(transcript_path, turn_start_fallback, pending_payloads, exp
     }
 
 
+SESSION_INPUT_MAX_CHARS = 4000
+
+
+def session_input_from_parsed(parsed):
+    """First user prompt of a parsed turn, for the session root's input.value headline stamp.
+    Returns "" when absent."""
+    for llm in parsed.get("llms", []):
+        attrs = llm.get("attributes", {}) or {}
+        index = 0
+        while f"gen_ai.prompt.{index}.role" in attrs:
+            if attrs.get(f"gen_ai.prompt.{index}.role") == "user":
+                text = str(attrs.get(f"gen_ai.prompt.{index}.content") or "")
+                if text:
+                    return text[:SESSION_INPUT_MAX_CHARS]
+            index += 1
+    return ""
+
+
+def session_input_attrs(session_input):
+    return {"input.value": session_input} if session_input else {}
+
+
 def build_stop_hook_span_specs(
     *,
     parsed,
@@ -413,6 +463,7 @@ def build_stop_hook_span_specs(
     session_start_ns,
     session_init_source,
     generate_span_id,
+    session_input="",
 ):
     turn = parsed.get("turn", {})
     turn_start_ns = str(turn.get("start_ns", session_start_ns))
@@ -430,15 +481,16 @@ def build_stop_hook_span_specs(
             trace_id=trace_id,
             span_id=session_span_id,
             parent_span_id=session_parent_span_id,
-            name="LLM Session",
+            name="Claude Code session",
             kind="1",
             start_ns=str(session_start_ns),
             end_ns=turn_end_ns,
             attrs={
                 "source": "claude-code",
                 "hook": session_hook_attr,
-                "node_type": "LLM_SESSION",
+                "node_type": "WORKFLOW",
                 "session.lifecycle": session_lifecycle_attr,
+                **session_input_attrs(session_input),
             },
         )
     ]

--- a/promptlayer/integrations/claude_agents/vendor/vendor_metadata.json
+++ b/promptlayer/integrations/claude_agents/vendor/vendor_metadata.json
@@ -1,5 +1,5 @@
 {
   "repository": "https://github.com/MagnivOrg/promptlayer-claude-plugins.git",
-  "commit_sha": "f5acd222d23b63ccda9cdf44b11f6cec6ee47e1e",
-  "timestamp": "2026-03-23T20:51:57Z"
+  "commit_sha": "60c4b17f7702b78aff890b42c2124dddaf70f3b5",
+  "timestamp": "2026-08-19T16:51:44Z"
 }

--- a/promptlayer/integrations/claude_agents/vendor/vendor_metadata.json
+++ b/promptlayer/integrations/claude_agents/vendor/vendor_metadata.json
@@ -1,5 +1,5 @@
 {
   "repository": "https://github.com/MagnivOrg/promptlayer-claude-plugins.git",
-  "commit_sha": "60c4b17f7702b78aff890b42c2124dddaf70f3b5",
-  "timestamp": "2026-08-19T16:51:44Z"
+  "commit_sha": "6db20e1ffac7f0bde428e9aed6dcc30bb81032c7",
+  "timestamp": "2026-08-19T19:25:40Z"
 }

--- a/promptlayer/integrations/openai_agents/mapping.py
+++ b/promptlayer/integrations/openai_agents/mapping.py
@@ -180,6 +180,30 @@ def _custom_attributes(span_data, *, include_raw_payloads: bool) -> dict[str, An
     return attrs
 
 
+def span_user_input(span_data) -> str | None:
+    """Last user message of an LLM span, for the root span's ``input.value`` headline stamp."""
+    span_type = span_data.type
+    if span_type == "generation":
+        return _last_message_content(normalize_messages(span_data.input), role="user")
+    if span_type == "response":
+        response_obj = _jsonable(getattr(span_data, "response", None))
+        response_obj = response_obj if isinstance(response_obj, Mapping) else {}
+        input_items = normalize_response_items(getattr(span_data, "input", None) or response_obj.get("input"))
+        return _last_message_content(input_items, role="user")
+    return None
+
+
+def _last_message_content(messages: list[dict[str, Any]], *, role: str) -> str | None:
+    return next(
+        (
+            str(message["content"])
+            for message in reversed(messages)
+            if message.get("role") == role and message.get("content")
+        ),
+        None,
+    )
+
+
 def normalize_messages(items: Sequence[Mapping[str, Any]] | None) -> list[dict[str, Any]]:
     if not isinstance(items, Sequence):
         return []

--- a/promptlayer/integrations/openai_agents/processor.py
+++ b/promptlayer/integrations/openai_agents/processor.py
@@ -12,8 +12,18 @@ from opentelemetry.trace.status import Status, StatusCode
 from promptlayer.tracing_context import resolve_tracer
 
 from .ids import hex_id_to_int, map_span_id, map_trace_id, synthetic_root_span_id
-from .mapping import base_span_attributes, base_trace_attributes, span_data_attributes, span_kind_for, span_name_for
+from .mapping import (
+    base_span_attributes,
+    base_trace_attributes,
+    span_data_attributes,
+    span_kind_for,
+    span_name_for,
+    span_user_input,
+)
 from .time import iso_to_unix_nano
+
+TRACE_INPUT_ATTRIBUTE = "input.value"
+_INPUT_VALUE_MAX_CHARS = 4000
 
 
 class _FixedIdGenerator(IdGenerator):
@@ -43,6 +53,7 @@ class PromptLayerOpenAIAgentsProcessor:
         self._root_spans: dict[str, trace_api.Span] = {}
         self._agent_spans: dict[str, trace_api.Span] = {}
         self._trace_members: dict[str, set[str]] = {}
+        self._trace_inputs: dict[str, str] = {}
 
     def on_trace_start(self, trace) -> None:
         parent_context = self._resolve_upstream_context(trace)
@@ -66,11 +77,14 @@ class PromptLayerOpenAIAgentsProcessor:
     def on_trace_end(self, trace) -> None:
         with self._lock:
             root_span = self._root_spans.pop(trace.trace_id, None)
+            trace_input = self._trace_inputs.pop(trace.trace_id, None)
             member_ids = self._trace_members.pop(trace.trace_id, set())
             for member_id in member_ids:
                 self._agent_spans.pop(member_id, None)
 
         if root_span is not None:
+            if trace_input:
+                root_span.set_attribute(TRACE_INPUT_ATTRIBUTE, trace_input[:_INPUT_VALUE_MAX_CHARS])
             root_span.end()
 
     def on_span_start(self, span) -> None:
@@ -104,6 +118,8 @@ class PromptLayerOpenAIAgentsProcessor:
         for key, value in span_data_attributes(span.span_data, include_raw_payloads=self._include_raw_payloads).items():
             otel_span.set_attribute(key, value)
 
+        self._record_trace_input(span)
+
         if span.error:
             message = span.error.get("message", "OpenAI Agents span error")
             otel_span.set_status(Status(StatusCode.ERROR, message))
@@ -125,6 +141,17 @@ class PromptLayerOpenAIAgentsProcessor:
 
     def force_flush(self) -> None:
         self._tracer_provider.force_flush()
+
+    def _record_trace_input(self, span) -> None:
+        """Keep the first user message seen in the trace as its input."""
+        with self._lock:
+            if span.trace_id in self._trace_inputs:
+                return
+        input_value = span_user_input(span.span_data)
+        if not input_value:
+            return
+        with self._lock:
+            self._trace_inputs.setdefault(span.trace_id, input_value)
 
     def _ensure_root_span(self, span):
         with self._lock:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "promptlayer"
-version = "1.5.15"
+version = "1.5.16"
 description = "PromptLayer is a platform for prompt engineering and tracks your LLM requests."
 authors = ["Magniv <hello@magniv.io>"]
 license = "Apache-2.0"

--- a/tests/test_eval_polling.py
+++ b/tests/test_eval_polling.py
@@ -277,6 +277,50 @@ async def test_live_progress_advances_cell_progress_for_matching_execution_id():
 
 
 @pytest.mark.asyncio
+async def test_live_progress_status_only_running_does_not_end_wait():
+    updates = []
+
+    @asynccontextmanager
+    async def fake_client(*_args, **_kwargs):
+        yield object()
+
+    @asynccontextmanager
+    async def fake_subscription(_client, _topic, message_listener):
+        # Status-only "running" must not invent 0/0/0 and trip count-based terminal.
+        await message_listener(
+            SMART_TABLE_EXECUTION_STATUS_UPDATE,
+            '{"execution_id":"exec-1","status":"running"}',
+        )
+        await message_listener(
+            SMART_TABLE_EXECUTION_STATUS_UPDATE,
+            '{"execution_id":"exec-1","status":"completed","total":2,"completed":2,"failed":0}',
+        )
+        yield
+
+    with (
+        patch(
+            "promptlayer.evaluations.live_progress._get_websocket_token",
+            new=AsyncMock(return_value={"token_details": {"token": "tok"}}),
+        ),
+        patch("promptlayer.evaluations.live_progress.centrifugo_client", side_effect=fake_client),
+        patch("promptlayer.evaluations.live_progress.centrifugo_subscription", side_effect=fake_subscription),
+    ):
+        states = await await_sheet_execution_progress(
+            api_key="key",
+            base_url="http://localhost:8000",
+            sheet_id="sheet-1",
+            execution_ids=["exec-1"],
+            on_execution_update=updates.append,
+            timeout_seconds=2.0,
+        )
+
+    assert [u.get("status") for u in updates] == ["running", "completed"]
+    assert "pending_count" not in updates[0]
+    assert states["exec-1"]["status"] == "completed"
+    assert states["exec-1"]["cell_count"] == 2
+
+
+@pytest.mark.asyncio
 async def test_live_progress_ignores_unrelated_execution_ids():
     updates = []
 
@@ -374,6 +418,29 @@ def test_smart_sheet_channel_and_payload_mapping():
     }
 
 
+def test_status_only_execution_update_does_not_invent_zero_counters():
+    from promptlayer.evaluations.live_progress import operation_payload_is_terminal
+
+    mapped = execution_update_to_operation_payload({"execution_id": "e1", "status": "running"})
+    assert mapped == {
+        "operation_id": "e1",
+        "execution_id": "e1",
+        "status": "running",
+    }
+    assert "pending_count" not in mapped
+    assert not operation_payload_is_terminal(mapped)
+    # Explicit zeros without a terminal status must also not end the wait.
+    assert not operation_payload_is_terminal(
+        {
+            "status": "running",
+            "pending_count": 0,
+            "completed_count": 0,
+            "failed_count": 0,
+            "cell_count": 0,
+        }
+    )
+
+
 def test_operation_is_terminal_when_cell_counts_finish_without_status():
     from promptlayer.evaluations.polling import _operation_is_terminal
 
@@ -397,6 +464,18 @@ def test_operation_is_terminal_when_cell_counts_finish_without_status():
                 "completed_count": 6,
                 "failed_count": 0,
                 "cell_count": 8,
+            },
+        }
+    )
+    assert not _operation_is_terminal(
+        {
+            "success": True,
+            "operation": {
+                "status": "running",
+                "pending_count": 0,
+                "completed_count": 0,
+                "failed_count": 0,
+                "cell_count": 0,
             },
         }
     )

--- a/tests/test_openai_agents_integration.py
+++ b/tests/test_openai_agents_integration.py
@@ -524,3 +524,48 @@ def test_normalize_response_items_preserves_openai_reasoning_summary():
             "content": "19 times 23 is 437.",
         },
     ]
+
+
+def test_root_span_stamped_with_first_user_message_only(in_memory_tracer_provider):
+    provider, exporter = in_memory_tracer_provider
+    processor = PromptLayerOpenAIAgentsProcessor(tracer_provider=provider)
+    set_trace_processors([processor])
+
+    with trace("Support run"):
+        with generation_span(
+            input=[
+                {"role": "system", "content": "You are a support agent."},
+                {"role": "user", "content": "Where is my order?"},
+            ],
+            output=[{"role": "assistant", "content": "Your order ships tomorrow."}],
+            model="gpt-4.1",
+        ):
+            pass
+        with function_span(name="notify", input="{}", output="ok"):
+            pass
+        with generation_span(
+            input=[{"role": "user", "content": "Thanks!"}],
+            output=[{"role": "assistant", "content": "Happy to help."}],
+            model="gpt-4.1",
+        ):
+            pass
+
+    root, _ = _find_root_and_child(_finished_spans(exporter))
+    root_attrs = dict(root.attributes)
+    # The opening user turn, not the system prompt and not a later turn
+    assert root_attrs["input.value"] == "Where is my order?"
+    # Output is deliberately left to request logs (last LLM reply is not reliably the answer)
+    assert "output.value" not in root_attrs
+
+
+def test_root_span_has_no_input_stamp_without_user_message(in_memory_tracer_provider):
+    provider, exporter = in_memory_tracer_provider
+    processor = PromptLayerOpenAIAgentsProcessor(tracer_provider=provider)
+    set_trace_processors([processor])
+
+    with trace("Tool only run"):
+        with function_span(name="notify", input="{}", output="ok"):
+            pass
+
+    root, _ = _find_root_and_child(_finished_spans(exporter))
+    assert "input.value" not in dict(root.attributes)


### PR DESCRIPTION
## Summary
The OpenAI Agents integration now stamps `input.value` on the synthetic `OpenAI session` root span with the run's **first user message**. The PromptLayer trace page reads that first for the trace-level Input, so agent traces show the user's question instead of the first LLM call's system prompt (the receipt fallback's first message).


## Changes
- `mapping.py`: `span_user_input()` — last `user` message of a `generation`/`response` span's input.
- `processor.py`: track the first user message seen per trace (`on_span_end`), stamp it as `input.value` on the root in `on_trace_end` (clipped to 4000 chars). Comment at the stamp site records why output is left alone.
- Version bump `1.5.14 → 1.5.15`.
- Tests: root gets the opening user turn (not the system prompt, not a later turn) and no `output.value`; tool-only runs get no input stamp.

## Test Plan
- [x] `pytest tests/test_openai_agents_integration.py tests/test_openai_agents_optional_dependency.py` — 16 passed; ruff check/format clean
- [x] Also ran the eval suites that share a tracer with this processor (`test_active_eval_tracer`, `test_evals`, `test_eval_scorers`, `test_eval_polling`) — 122 passed total
- [x] Live against a local backend: agent with system instructions → root `input.value` = user question, `output.value` absent, trace headline Input via root stamp / Output via receipt
